### PR TITLE
Add .env requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules
 .DS_Store
+.env

--- a/index.html
+++ b/index.html
@@ -2,12 +2,18 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title>Hello World!</title>
   </head>
   <body>
     <div id="content"></div>
   </body>
   <script>
-    require('./snoozer.js')
+    const Main = require('./components/Main')
+    const React = require('react')
+    const ReactDOM = require('react-dom')
+
+    ReactDOM.render(
+      React.createElement(Main, null),
+      document.getElementById('content')
+    )
   </script>
 </html>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "spectron": "^3.2.6"
   },
   "scripts": {
-    "start": "./node_modules/.bin/electron .",
+    "start": "./scripts/verify-token && ./node_modules/.bin/electron .",
     "test": "mocha"
   },
   "repository": {

--- a/scripts/verify-token
+++ b/scripts/verify-token
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const path = require('path')
+
+try {
+  const token = fs.readFileSync(path.join(__dirname, '../.env')).toString()
+  if (!token || !token.match(/^\s*[\w]{40}\s*$/)) {
+    exit(1)
+  }
+}
+catch(error) {
+  exit(1)
+}
+
+function exit() {
+  console.log("You must have a `.env` file containing a GitHub personal access token.")
+  console.log("----------------------------------------------------------------------")
+  console.log("")
+  console.log("1. Create the token at https://github.com/settings/tokens/new. Make sure it has the `repo` scope.")
+  console.log("2. From the shell run `echo TOKEN > .env`. TOKEN is the token you got in step one")
+  console.log("3. You are all set!")
+  process.exit(1);
+}

--- a/snoozer.js
+++ b/snoozer.js
@@ -1,8 +1,0 @@
-const Main = require('./components/Main')
-const React = require('react')
-const ReactDOM = require('react-dom')
-
-ReactDOM.render(
-  React.createElement(Main, null),
-  document.getElementById('content')
-)


### PR DESCRIPTION
This PR does two things.
1. Makes sure you have a .env file with a token in it. This is for dev purposes only, so we don't have to spend time working on the oauth flow.
2. Remove the `snoozer.js` file and move its logic into the `index.html` file. I did this because the snoozer logic is so minimal.

Closes #3

cc @cheshire137 
