### PR TITLE
Add menus, About page

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,4 +1,5 @@
 {
   "githubApiUrl": "https://api.github.com",
-  "searchQuery": ""
+  "searchQuery": "",
+  "bugReportUrl": "https://github.com/cheshire137/gh-notifications-snoozer/issues/new"
 }

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,4 @@
 {
   "githubApiUrl": "https://api.github.com",
-  "searchQuery": "",
-  "bugReportUrl": "https://github.com/cheshire137/gh-notifications-snoozer/issues/new"
+  "searchQuery": ""
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "gh-notifications-snoozer",
+  "productName": "GitHub Notifications Snoozer",
   "version": "0.0.1",
   "description": "An easier way to deal with github notifications",
   "main": "src/main.js",

--- a/package.json
+++ b/package.json
@@ -23,18 +23,17 @@
     "eslint-plugin-jsx-a11y": "^2.0.1",
     "eslint-plugin-react": "^5.2.2",
     "fetch-mock": "^5.0.2",
-    "jsdom": "^9.4.1",
     "mocha": "^2.5.3",
     "react-addons-test-utils": "^15.2.1",
-    "xvfb-maybe": "^0.1.3",
-    "redux-devtools": "^3.3.1"
+    "redux-devtools": "^3.3.1",
+    "xvfb-maybe": "^0.1.3"
   },
   "scripts": {
     "postinstall": "if [ ! -f src/config.json ]; then cp config.json.example src/config.json; fi; if [ ! -f .env ]; then touch .env; fi",
     "start": "electron src/main.js",
     "style": "eslint -c .eslintrc *.js scripts/* src/*.js src/**/*.jsx test/**/*.js",
-    "unit-tests": "xvfb-maybe electron-mocha --recursive --compilers js:babel-register test",
     "test": "npm run-script style && npm run-script unit-tests"
+    "unit-tests": "xvfb-maybe electron-mocha --renderer --recursive --compilers js:babel-register test",
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "electron src/main.js",
     "style": "eslint -c .eslintrc *.js scripts/* src/*.js src/**/*.jsx test/**/*.js",
     "unit-tests": "xvfb-maybe electron-mocha --renderer --recursive --compilers js:babel-register test",
-    "test": "npm run-script style && npm run-script unit-tests",
+    "test": "npm run-script style && npm run-script unit-tests"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "postinstall": "if [ ! -f src/config.json ]; then cp config.json.example src/config.json; fi; if [ ! -f .env ]; then touch .env; fi",
     "start": "electron src/main.js",
     "style": "eslint -c .eslintrc *.js scripts/* src/*.js src/**/*.jsx test/**/*.js",
-    "test": "npm run-script style && npm run-script unit-tests"
     "unit-tests": "xvfb-maybe electron-mocha --renderer --recursive --compilers js:babel-register test",
+    "test": "npm run-script style && npm run-script unit-tests",
   },
   "repository": {
     "type": "git",

--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -1,6 +1,5 @@
-const { shell } = require('electron')
+const { shell, remote } = require('electron')
 const React = require('react')
-const { remote } = require('electron')
 const { app } = remote
 
 class About extends React.Component {

--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -1,3 +1,4 @@
+const { shell } = require('electron')
 const React = require('react')
 const path = require('path')
 const packagePath = path.join(__dirname, '..', '..', '..', 'package.json')
@@ -9,6 +10,13 @@ class About extends React.Component {
     this.props.cancel()
   }
 
+  handleLinkClick(event) {
+    event.preventDefault()
+    const link = event.currentTarget
+    link.blur()
+    shell.openExternal(link.href)
+  }
+
   render() {
     return (
       <div>
@@ -17,6 +25,19 @@ class About extends React.Component {
           <span> / </span>
           About
         </h1>
+        <p>
+          {packageInfo.productName}
+          <span> was built by </span>
+          <a
+            href="https://github.com/probablycorey"
+            onClick={e => this.handleLinkClick(e)}
+          >@probablycorey</a>
+          <span> and </span>
+          <a
+            href="https://github.com/cheshire137"
+            onClick={e => this.handleLinkClick(e)}
+          >@cheshire137</a>.
+        </p>
         <p>
           <strong>Version: </strong> {packageInfo.version}
         </p>

--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -1,8 +1,7 @@
 const { shell } = require('electron')
 const React = require('react')
-const path = require('path')
-const packagePath = path.join(__dirname, '..', '..', '..', 'package.json')
-const packageInfo = require(packagePath)
+const { remote } = require('electron')
+const { app } = remote
 
 class About extends React.Component {
   cancel(event) {
@@ -26,7 +25,7 @@ class About extends React.Component {
           About
         </h1>
         <p>
-          {packageInfo.productName}
+          {app.getName()}
           <span> was built by </span>
           <a
             href="https://github.com/probablycorey"
@@ -39,7 +38,7 @@ class About extends React.Component {
           >@cheshire137</a>.
         </p>
         <p>
-          <strong>Version: </strong> {packageInfo.version}
+          <strong>Version: </strong> {app.getVersion()}
         </p>
       </div>
     )

--- a/src/components/About/About.jsx
+++ b/src/components/About/About.jsx
@@ -1,0 +1,32 @@
+const React = require('react')
+const path = require('path')
+const packagePath = path.join(__dirname, '..', '..', '..', 'package.json')
+const packageInfo = require(packagePath)
+
+class About extends React.Component {
+  cancel(event) {
+    event.preventDefault()
+    this.props.cancel()
+  }
+
+  render() {
+    return (
+      <div>
+        <h1 className="title">
+          <a href="#" onClick={event => this.cancel(event)}>Tasks</a>
+          <span> / </span>
+          About
+        </h1>
+        <p>
+          <strong>Version: </strong> {packageInfo.version}
+        </p>
+      </div>
+    )
+  }
+}
+
+About.propTypes = {
+  cancel: React.PropTypes.func.isRequired,
+}
+
+module.exports = About

--- a/src/components/About/package.json
+++ b/src/components/About/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "About",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./About.jsx"
+}

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -32,6 +32,7 @@ class App extends React.Component {
   setupAppMenu() {
     const menu = new AppMenu()
     menu.on('about-app', () => {
+      ipcRenderer.send('title', 'About')
       this.setState({ view: 'about' })
     })
   }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -5,11 +5,13 @@ const { ipcRenderer } = require('electron')
 const Rule = require('../../models/rule')
 const Rules = require('../../models/rules')
 const GitHub = require('../../models/github')
+const AppMenu = require('../../models/app-menu')
 const Filter = require('../Filter')
 const TaskList = require('../TaskList')
 const RuleList = require('../RuleList')
 const NewRule = require('../NewRule')
 const Config = require('../../config.json')
+const About = require('../About')
 
 class App extends React.Component {
   constructor() {
@@ -24,6 +26,14 @@ class App extends React.Component {
     } else {
       this.loadTasks(Config.searchQuery)
     }
+    this.setupAppMenu()
+  }
+
+  setupAppMenu() {
+    const menu = new AppMenu()
+    menu.on('about-app', () => {
+      this.setState({ view: 'about' })
+    })
   }
 
   loadTasks(query) {
@@ -86,6 +96,14 @@ class App extends React.Component {
           rules={this.state.rules}
           delete={(ruleKey) => this.deleteRule(ruleKey)}
           addRule={() => this.showNewRuleForm()}
+          cancel={() => this.showTaskList()}
+        />
+      )
+    }
+
+    if (this.state.view === 'about') {
+      return (
+        <About
           cancel={() => this.showTaskList()}
         />
       )

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -1,5 +1,6 @@
 const { connect } = require('react-redux')
 const React = require('react')
+const { ipcRenderer } = require('electron')
 
 const Rule = require('../../models/rule')
 const Rules = require('../../models/rules')
@@ -17,6 +18,7 @@ class App extends React.Component {
   }
 
   componentDidMount() {
+    ipcRenderer.send('title', 'Notifications')
     if (this.state.rules.length > 0) {
       this.loadRule(this.state.rules[0])
     } else {
@@ -32,14 +34,17 @@ class App extends React.Component {
   }
 
   showNewRuleForm() {
+    ipcRenderer.send('title', 'New Filter')
     this.setState({ view: 'new-rule' })
   }
 
   savedRule() {
+    ipcRenderer.send('title', 'Notifications')
     this.setState({ view: 'tasks', rules: Rules.findAll() })
   }
 
   showTaskList() {
+    ipcRenderer.send('title', 'Notifications')
     this.setState({ view: 'tasks' })
   }
 
@@ -51,6 +56,7 @@ class App extends React.Component {
   }
 
   manageRules() {
+    ipcRenderer.send('title', 'Manage Filters')
     this.setState({ view: 'rules' })
   }
 

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -1,5 +1,5 @@
 const React = require('react')
-const shell = require('electron').shell
+const { shell } = require('electron')
 const { connect } = require('react-redux')
 
 class TaskListItem extends React.Component {

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
       const ReactRedux = require('react-redux')
       const Redux = require('redux')
       const Electron = require('electron').remote
-      const {persistStore, autoRehydrate} = require('redux-persist')
+      const { persistStore, autoRehydrate } = require('redux-persist')
       const { AsyncNodeStorage } = require('redux-persist-node-storage')
 
       const App = require('./components/App')

--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,7 @@
       const ReactDom = require('react-dom')
       const ReactRedux = require('react-redux')
       const Redux = require('redux')
-      const Electron = require('electron').remote
+      const { remote } = require('electron')
       const { persistStore, autoRehydrate } = require('redux-persist')
       const { AsyncNodeStorage } = require('redux-persist-node-storage')
 
@@ -20,7 +20,7 @@
       const reducer = require('./reducers/reducer')
       const store = Redux.createStore(reducer, undefined, autoRehydrate())
 
-      const persistDir = Electron.app.getPath('userData')
+      const persistDir = remote.app.getPath('userData')
       const persistOptions = { storage: new AsyncNodeStorage(persistDir) }
       persistStore(store, persistOptions)
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,52 +1,30 @@
 const electron = require('electron')
-// Module to control application life.
 const app = electron.app
-// Module to create native browser window.
 const BrowserWindow = electron.BrowserWindow
 
-// Keep a global reference of the window object, if you don't, the window will
-// be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
 
 function createWindow() {
-  // Create the browser window.
   mainWindow = new BrowserWindow({ width: 800, height: 600 })
-
-  // and load the index.html of the app.
   mainWindow.loadURL(`file://${__dirname}/index.html`)
 
   // mainWindow.webContents.openDevTools()
 
-  // Emitted when the window is closed.
   mainWindow.on('closed', () => {
-    // Dereference the window object, usually you would store windows
-    // in an array if your app supports multi windows, this is the time
-    // when you should delete the corresponding element.
     mainWindow = null
   })
 }
 
-// This method will be called when Electron has finished
-// initialization and is ready to create browser windows.
-// Some APIs can only be used after this event occurs.
 app.on('ready', createWindow)
 
-// Quit when all windows are closed.
 app.on('window-all-closed', () => {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
   if (process.platform !== 'darwin') {
     app.quit()
   }
 })
 
 app.on('activate', () => {
-  // On OS X it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
   if (mainWindow === null) {
     createWindow()
   }
 })
-
-// In this file you can include the rest of your app's specific main process
-// code. You can also put them in separate files and require them here.

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,34 @@
 const electron = require('electron')
 const app = electron.app
 const BrowserWindow = electron.BrowserWindow
+const path = require('path')
+const packageInfo = require(path.join(__dirname, '..', 'package.json'))
 
 let mainWindow
 
+function onTitleChange(event, prefix) {
+  let title = ''
+  if (typeof prefix === 'string' && prefix.length > 0) {
+    title += `${prefix} - `
+  }
+  title += packageInfo.productName
+  mainWindow.setTitle(title)
+}
+
 function createWindow() {
-  mainWindow = new BrowserWindow({ width: 800, height: 600 })
+  app.setName('')
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    title: packageInfo.productName,
+  })
   mainWindow.loadURL(`file://${__dirname}/index.html`)
 
   // mainWindow.webContents.openDevTools()
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    electron.ipcMain.on('title', onTitleChange)
+  })
 
   mainWindow.on('closed', () => {
     mainWindow = null

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,6 @@
 const electron = require('electron')
 const app = electron.app
 const BrowserWindow = electron.BrowserWindow
-const path = require('path')
-const packageInfo = require(path.join(__dirname, '..', 'package.json'))
 
 let mainWindow
 
@@ -11,7 +9,7 @@ function onTitleChange(event, prefix) {
   if (typeof prefix === 'string' && prefix.length > 0) {
     title += `${prefix} - `
   }
-  title += packageInfo.productName
+  title += app.getName()
   mainWindow.setTitle(title)
 }
 
@@ -20,7 +18,7 @@ function createWindow() {
   mainWindow = new BrowserWindow({
     width: 800,
     height: 600,
-    title: packageInfo.productName,
+    title: app.getName(),
   })
   mainWindow.loadURL(`file://${__dirname}/index.html`)
 

--- a/src/models/app-menu.js
+++ b/src/models/app-menu.js
@@ -3,7 +3,9 @@
 const { remote, shell } = require('electron')
 const { Menu, app } = remote
 const EventEmitter = require('events')
-const Config = require('../config.json')
+const path = require('path')
+const packagePath = path.join(__dirname, '..', '..', 'package.json')
+const packageInfo = require(packagePath)
 
 class AppMenu extends EventEmitter {
   constructor() {
@@ -16,7 +18,7 @@ class AppMenu extends EventEmitter {
     }
     this.bugReportOption = {
       label: 'Report a bug',
-      click() { shell.openExternal(Config.bugReportUrl) },
+      click() { shell.openExternal(packageInfo.bugs.url) },
     }
     this.buildMenu()
     Menu.setApplicationMenu(Menu.buildFromTemplate(this.template))

--- a/src/models/app-menu.js
+++ b/src/models/app-menu.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const { remote, shell } = require('electron')
+const { Menu, app } = remote
+const EventEmitter = require('events')
+const Config = require('../config.json')
+
+class AppMenu extends EventEmitter {
+  constructor() {
+    super()
+    this.template = []
+    const self = this
+    this.aboutOption = {
+      label: `About ${app.getName()}`,
+      click() { self.emit('about-app') },
+    }
+    this.bugReportOption = {
+      label: 'Report a bug',
+      click() { shell.openExternal(Config.bugReportUrl) },
+    }
+    this.buildMenu()
+    Menu.setApplicationMenu(Menu.buildFromTemplate(this.template))
+  }
+
+  buildMenu() {
+    if (process.platform === 'darwin') {
+      this.buildOSXMenu()
+    } else {
+      this.buildNonOSXMenu()
+    }
+  }
+
+  buildOSXMenu() {
+    this.template.push({
+      label: app.getName(),
+      submenu: [
+        this.aboutOption,
+        {
+          label: 'Quit',
+          accelerator: 'Command+Q',
+          click() { app.quit() },
+        },
+      ],
+    })
+    this.template.push({
+      label: 'Help',
+      role: 'help',
+      submenu: [
+        this.bugReportOption,
+      ],
+    })
+  }
+
+  buildNonOSXMenu() {
+    this.template.push({
+      label: 'File',
+      submenu: [
+        {
+          label: 'Exit',
+          accelerator: 'Ctrl+Q',
+          click() { app.quit() },
+        },
+      ],
+    })
+    this.template.push({
+      label: 'Help',
+      submenu: [
+        this.aboutOption,
+        this.bugReportOption,
+      ],
+    })
+  }
+}
+
+module.exports = AppMenu

--- a/test/components/App-test.js
+++ b/test/components/App-test.js
@@ -1,5 +1,4 @@
 const assert = require('assert')
-const jsdom = require('jsdom')
 const React = require('react')
 const ReactDOM = require('react-dom')
 const ReactRedux = require('react-redux')
@@ -14,9 +13,6 @@ describe('App', () => {
   let store
 
   before(() => {
-    global.document = jsdom.jsdom('<!doctype html><html><body></body></html>')
-    global.window = global.document.defaultView
-
     store = Redux.createStore(reducer)
     fetchMock.mock('*', {})
   })

--- a/test/components/TaskList-test.js
+++ b/test/components/TaskList-test.js
@@ -3,18 +3,18 @@ describe('TaskList', () => {
 
   context('when the snooze button is clicked', () => {
     it('hides selected tasks')
-    it('updates the selected task\'s `snooze_until` field')
+    it("updates the selected task's `snooze_until` field")
     it('shows the tasks again, starting at midnight of the next day')
   })
 
   context('when the archive button is clicked', () => {
     it('hides selected tasks')
-    it('updates the selected task\'s `archived_at` field')
+    it("updates the selected task's `archived_at` field")
     it('shows tasks again if `updated_at` is greater than `archived_at`')
   })
 
   context('when the ignore button is clicked', () => {
     it('hides selected tasks')
-    it('updates the selected task\'s `ignored` field')
+    it("updates the selected task's `ignored` field")
   })
 })


### PR DESCRIPTION
Fixes #19 by adding an application-wide menu. There seems to be a bug right now where the app thinks its name is 'Electron' even though 'name' and 'productName' are both specified in package.json. Likewise, it says the wrong version on the About page, coming from `app.getVersion()`.

This also sets the title of the window based on which view you're on.

/cc @probablycorey 
