### PR TITLE
Allow editing filters

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -114,6 +114,7 @@ class App extends React.Component {
         <EditFilter
           filter={this.state.filter}
           save={() => this.savedFilter()}
+          addFilter={() => this.showNewFilterForm()}
           cancel={() => this.manageFilters()}
           delete={key => this.deleteFilter(key)}
         />
@@ -132,6 +133,7 @@ class App extends React.Component {
       <NewFilter
         save={() => this.savedFilter()}
         cancel={() => this.showTaskList()}
+        manageFilters={() => this.manageFilters()}
       />
     )
   }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -115,6 +115,7 @@ class App extends React.Component {
           filter={this.state.filter}
           save={() => this.savedFilter()}
           cancel={() => this.manageFilters()}
+          delete={key => this.deleteFilter(key)}
         />
       )
     }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -10,6 +10,7 @@ const TopNavigation = require('../TopNavigation')
 const TaskList = require('../TaskList')
 const FilterList = require('../FilterList')
 const NewFilter = require('../NewFilter')
+const EditFilter = require('../EditFilter')
 const Config = require('../../config.json')
 const About = require('../About')
 
@@ -77,6 +78,11 @@ class App extends React.Component {
     this.setState({ filters: remainingFilters })
   }
 
+  editFilter(key) {
+    const filter = new Filter(key)
+    this.setState({ filter, view: 'edit-filter' })
+  }
+
   render() {
     if (this.state.view === 'tasks') {
       return (
@@ -96,8 +102,19 @@ class App extends React.Component {
         <FilterList
           filters={this.state.filters}
           delete={key => this.deleteFilter(key)}
+          edit={key => this.editFilter(key)}
           addFilter={() => this.showNewFilterForm()}
           cancel={() => this.showTaskList()}
+        />
+      )
+    }
+
+    if (this.state.view === 'edit-filter') {
+      return (
+        <EditFilter
+          filter={this.state.filter}
+          save={() => this.savedFilter()}
+          cancel={() => this.manageFilters()}
         />
       )
     }

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -2,6 +2,7 @@
 @import "https://cdnjs.cloudflare.com/ajax/libs/octicons/3.5.0/octicons.min.css";
 @import "../TopNavigation/TopNavigation.less";
 @import "../NewFilter/NewFilter.less";
+@import "../EditFilter/EditFilter.less";
 @import "../FilterList/FilterList.less";
 @import "../FilterListItem/FilterListItem.less";
 @import "../TaskList/TaskList.less";

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -5,6 +5,7 @@
 @import "../EditFilter/EditFilter.less";
 @import "../FilterList/FilterList.less";
 @import "../FilterListItem/FilterListItem.less";
+@import "../FilterHelp/FilterHelp.less";
 @import "../TaskList/TaskList.less";
 @import "../TaskListItem/TaskListItem.less";
 
@@ -19,9 +20,4 @@ body {
 
 .button.is-primary {
   margin-right: 5px;
-}
-
-.search-query-help li {
-  text-indent: -2em;
-  margin: 0 0 10px 2em;
 }

--- a/src/components/EditFilter/EditFilter.jsx
+++ b/src/components/EditFilter/EditFilter.jsx
@@ -51,12 +51,32 @@ class EditFilter extends React.Component {
     }
     return (
       <div>
-        <h1 className="title">
-          <a href="#" onClick={event => this.cancel(event)}>Tasks</a>
-          <span> / </span>
-          Edit Filter
-        </h1>
-        <form className="new-filter-form" onSubmit={event => this.save(event)}>
+        <div className="columns edit-filter-top-navigation">
+          <div className="column is-7">
+            <h1 className="title">
+              <a href="#" onClick={event => this.cancel(event)}>
+                Manage Filters
+              </a>
+              <span> / </span>
+              Edit Filter
+            </h1>
+          </div>
+          <div className="column is-5 has-text-right">
+            <button
+              onClick={event => this.cancel(event)}
+              type="button"
+              className="is-link button"
+              title="Manage filters"
+            ><span className="octicon octicon-three-bars"></span></button>
+            <button
+              onClick={this.props.addFilter}
+              type="button"
+              className="is-link button"
+              title="Add a filter"
+            ><span className="octicon octicon-plus"></span></button>
+          </div>
+        </div>
+        <form className="edit-filter-form" onSubmit={event => this.save(event)}>
           <label className="label">Search query:</label>
           <p className="control">
             <input
@@ -99,6 +119,7 @@ EditFilter.propTypes = {
   filter: React.PropTypes.object.isRequired,
   save: React.PropTypes.func.isRequired,
   cancel: React.PropTypes.func.isRequired,
+  addFilter: React.PropTypes.func.isRequired,
   delete: React.PropTypes.func.isRequired,
 }
 

--- a/src/components/EditFilter/EditFilter.jsx
+++ b/src/components/EditFilter/EditFilter.jsx
@@ -14,18 +14,20 @@ class EditFilter extends React.Component {
 
   save(event) {
     event.preventDefault()
-    const form = event.target
     if (this.state.value.length < 1) {
       this.setState({ valueHasError: true })
       return
     }
     this.setState({ valueHasError: false })
-    let key = form.filterKey.value.trim()
+    let key = this.state.key.trim()
     if (key.length < 1) {
       key = this.state.value
     }
     const filter = new Filter(key)
     filter.store(this.state.value)
+    if (this.props.filter.key !== key) {
+      this.props.delete(this.props.filter.key)
+    }
     this.props.save(key)
   }
 
@@ -35,11 +37,11 @@ class EditFilter extends React.Component {
   }
 
   valueChanged(event) {
-    this.setState({ value: event.target.value.trim() })
+    this.setState({ value: event.target.value })
   }
 
   keyChanged(event) {
-    this.setState({ key: event.target.value.trim() })
+    this.setState({ key: event.target.value })
   }
 
   render() {
@@ -97,6 +99,7 @@ EditFilter.propTypes = {
   filter: React.PropTypes.object.isRequired,
   save: React.PropTypes.func.isRequired,
   cancel: React.PropTypes.func.isRequired,
+  delete: React.PropTypes.func.isRequired,
 }
 
 module.exports = EditFilter

--- a/src/components/EditFilter/EditFilter.jsx
+++ b/src/components/EditFilter/EditFilter.jsx
@@ -1,0 +1,102 @@
+const React = require('react')
+const Filter = require('../../models/filter')
+
+class EditFilter extends React.Component {
+  constructor(props) {
+    super(props)
+    const { filter } = props
+    this.state = {
+      valueHasError: false,
+      key: filter.key,
+      value: filter.retrieve(),
+    }
+  }
+
+  save(event) {
+    event.preventDefault()
+    const form = event.target
+    if (this.state.value.length < 1) {
+      this.setState({ valueHasError: true })
+      return
+    }
+    this.setState({ valueHasError: false })
+    let key = form.filterKey.value.trim()
+    if (key.length < 1) {
+      key = this.state.value
+    }
+    const filter = new Filter(key)
+    filter.store(this.state.value)
+    this.props.save(key)
+  }
+
+  cancel(event) {
+    event.preventDefault()
+    this.props.cancel()
+  }
+
+  valueChanged(event) {
+    this.setState({ value: event.target.value.trim() })
+  }
+
+  keyChanged(event) {
+    this.setState({ key: event.target.value.trim() })
+  }
+
+  render() {
+    let valueClass = 'input'
+    if (this.state.valueHasError) {
+      valueClass += ' is-danger'
+    }
+    return (
+      <div>
+        <h1 className="title">
+          <a href="#" onClick={event => this.cancel(event)}>Tasks</a>
+          <span> / </span>
+          Edit Filter
+        </h1>
+        <form className="new-filter-form" onSubmit={event => this.save(event)}>
+          <label className="label">Search query:</label>
+          <p className="control">
+            <input
+              type="text"
+              name="filterValue"
+              className={valueClass}
+              value={this.state.value}
+              onChange={e => this.valueChanged(e)}
+              placeholder="e.g., team:org/team-name is:open"
+            />
+          </p>
+          <label className="label">Filter name: (optional)</label>
+          <p className="control">
+            <input
+              type="text"
+              name="filterKey"
+              className="input"
+              value={this.state.key}
+              onChange={e => this.keyChanged(e)}
+              placeholder="e.g., Team mentions"
+            />
+          </p>
+          <p className="control">
+            <button type="submit" className="button is-primary">
+              Save Filter
+            </button>
+            <button
+              type="button"
+              onClick={this.props.cancel}
+              className="button is-link"
+            >Cancel</button>
+          </p>
+        </form>
+      </div>
+    )
+  }
+}
+
+EditFilter.propTypes = {
+  filter: React.PropTypes.object.isRequired,
+  save: React.PropTypes.func.isRequired,
+  cancel: React.PropTypes.func.isRequired,
+}
+
+module.exports = EditFilter

--- a/src/components/EditFilter/EditFilter.jsx
+++ b/src/components/EditFilter/EditFilter.jsx
@@ -1,5 +1,6 @@
 const React = require('react')
 const Filter = require('../../models/filter')
+const FilterHelp = require('../FilterHelp')
 
 class EditFilter extends React.Component {
   constructor(props) {
@@ -110,6 +111,7 @@ class EditFilter extends React.Component {
             >Cancel</button>
           </p>
         </form>
+        <FilterHelp />
       </div>
     )
   }

--- a/src/components/EditFilter/EditFilter.less
+++ b/src/components/EditFilter/EditFilter.less
@@ -1,0 +1,11 @@
+.edit-filter-form {
+}
+
+.edit-filter-top-navigation.columns {
+  border-bottom: 1px solid rgba(211, 214, 219, 0.5);
+  margin-bottom: 15px;
+
+  .is-link {
+    text-decoration: none;
+  }
+}

--- a/src/components/EditFilter/EditFilter.less
+++ b/src/components/EditFilter/EditFilter.less
@@ -1,4 +1,5 @@
 .edit-filter-form {
+  margin-bottom: 40px;
 }
 
 .edit-filter-top-navigation.columns {

--- a/src/components/EditFilter/package.json
+++ b/src/components/EditFilter/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "EditFilter",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./EditFilter.jsx"
+}

--- a/src/components/FilterHelp/FilterHelp.jsx
+++ b/src/components/FilterHelp/FilterHelp.jsx
@@ -1,0 +1,104 @@
+const React = require('react')
+
+class FilterHelp extends React.Component {
+  render() {
+    return (
+      <div className="filter-help-container">
+        <h2 className="subtitle">Search Query Help</h2>
+        <ul className="search-query-help">
+          <li>
+            <code>type</code> &mdash; With this qualifier you can restrict the
+            search to issues (<code>issue</code>) or pull request
+            (<code>pr</code>) only.
+          </li>
+          <li>
+            <code>in</code> &mdash; Qualifies which fields are searched. With
+            this qualifier you can restrict the search to just the title
+            (<code>title</code>), body (<code>body</code>), comments
+            (<code>comments</code>), or any combination of these.
+          </li>
+          <li>
+            <code>author</code> &mdash; Finds issues or pull requests created
+            by a certain user.
+          </li>
+          <li>
+            <code>assignee</code> &mdash; Finds issues or pull requests that
+            are assigned to a certain user.
+          </li>
+          <li>
+            <code>mentions</code> &mdash; Finds issues or pull requests that
+            mention a certain user.
+          </li>
+          <li>
+            <code>commenter</code> &mdash; Finds issues or pull requests that
+            a certain user commented on.
+          </li>
+          <li>
+            <code>involves</code> &mdash; Finds issues or pull requests that
+            were either created by a certain user, assigned to that user,
+            mention that user, or were commented on by that user.
+          </li>
+          <li>
+            <code>team</code> &mdash; For organizations you're a member of,
+            finds issues or pull requests that @mention a team within the
+            organization.
+          </li>
+          <li>
+            <code>state</code> &mdash; Filter issues or pull requests based on
+            whether they're open or closed.
+          </li>
+          <li>
+            <code>labels</code> &mdash; Filters issues or pull requests based
+            on their labels.
+          </li>
+          <li>
+            <code>no</code> &mdash; Filters items missing certain metadata,
+            such as <code>label</code>, <code>milestone</code>, or
+            <code>assignee</code>.
+          </li>
+          <li>
+            <code>language</code> &mdash; Searches for issues or pull requests
+            within repositories that match a certain language.
+          </li>
+          <li>
+            <code>is</code> &mdash; Searches for items within repositories that
+            match a certain state, such as <code>open</code>,
+            <code>closed</code>, or <code>merged</code>
+          </li>
+          <li>
+            <code>created</code> or <code>updated</code> &mdash; Filters issues
+            or pull requests based on date of creation, or when they were last
+            updated.
+          </li>
+          <li>
+            <code>merged</code> &mdash; Filters pull requests based on the date
+            when they were merged.
+          </li>
+          <li>
+            <code>status</code> &mdash; Filters pull requests based on the
+            commit status.
+          </li>
+          <li>
+            <code>head</code> or <code>base</code> &mdash; Filters pull
+            requests based on the branch that they came from or that they are
+            modifying.
+          </li>
+          <li>
+            <code>closed</code> &mdash; Filters issues or pull requests based
+            on the date when they were closed.
+          </li>
+          <li>
+            <code>comments</code> &mdash; Filters issues or pull requests based
+            on the quantity of comments.
+          </li>
+          <li>
+            <code>user</code> or <code>repo</code> &mdash; Limits searches to a
+            specific user or repository.
+          </li>
+        </ul>
+      </div>
+    )
+  }
+}
+
+module.exports = FilterHelp

--- a/src/components/FilterHelp/FilterHelp.less
+++ b/src/components/FilterHelp/FilterHelp.less
@@ -1,0 +1,7 @@
+.search-query-help li {
+  text-indent: -2em;
+  margin: 0 0 10px 2em;
+}
+
+.filter-help-container {
+}

--- a/src/components/FilterHelp/package.json
+++ b/src/components/FilterHelp/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "FilterHelp",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./FilterHelp.jsx"
+}

--- a/src/components/FilterList/FilterList.jsx
+++ b/src/components/FilterList/FilterList.jsx
@@ -35,6 +35,7 @@ class FilterList extends React.Component {
                 key={key}
                 filter={key}
                 delete={this.props.delete}
+                edit={this.props.edit}
               />
             ))}
           </ul>
@@ -47,6 +48,7 @@ class FilterList extends React.Component {
 FilterList.propTypes = {
   filters: React.PropTypes.array.isRequired,
   delete: React.PropTypes.func.isRequired,
+  edit: React.PropTypes.func.isRequired,
   addFilter: React.PropTypes.func.isRequired,
   cancel: React.PropTypes.func.isRequired,
 }

--- a/src/components/FilterList/FilterList.jsx
+++ b/src/components/FilterList/FilterList.jsx
@@ -9,25 +9,29 @@ class FilterList extends React.Component {
 
   render() {
     return (
-      <div>
-        <div className="columns">
-          <div className="column is-6">
+      <div className="filter-list-container">
+        <div className="columns filter-list-top-navigation">
+          <div className="column is-7">
             <h1 className="title">
               <a href="#" onClick={event => this.cancel(event)}>Tasks</a>
               <span> / </span>
               Manage Filters
             </h1>
           </div>
-          <div className="column is-6 has-text-right">
+          <div className="column is-5 has-text-right">
             <button
               onClick={this.props.addFilter}
               type="button"
-              className="button"
-            >Add a filter</button>
+              className="button is-link"
+              title="Add a filter"
+            ><span className="octicon octicon-plus"></span></button>
           </div>
         </div>
         {this.props.filters.length < 1 ? (
-          <p>You have not made any filters for managing notifications yet.</p>
+          <p>
+            You have not added any filters yet. Use filters to manage which
+            issues and pull requests are displayed.
+          </p>
         ) : (
           <ul className="filter-list">
             {this.props.filters.map(key => (

--- a/src/components/FilterList/FilterList.less
+++ b/src/components/FilterList/FilterList.less
@@ -1,0 +1,15 @@
+.filter-list-container {
+}
+
+.filter-list-top-navigation.columns {
+  border-bottom: 1px solid rgba(211, 214, 219, 0.5);
+  margin-bottom: 15px;
+
+  .column {
+    padding-bottom: 15px;
+  }
+
+  .is-link {
+    text-decoration: none;
+  }
+}

--- a/src/components/FilterListItem/FilterListItem.jsx
+++ b/src/components/FilterListItem/FilterListItem.jsx
@@ -16,10 +16,21 @@ class FilterListItem extends React.Component {
           </div>
           <div className="column is-2 has-text-right">
             <button
+              onClick={() => this.props.edit(this.props.filter)}
+              type="button"
+              className="button is-link"
+              title="Edit filter"
+            >
+              <span className="octicon octicon-pencil"></span>
+            </button>
+            <button
               onClick={() => this.props.delete(this.props.filter)}
               type="button"
-              className="button"
-            >Delete</button>
+              className="button is-link"
+              title="Delete filter"
+            >
+              <span className="octicon octicon-trashcan"></span>
+            </button>
           </div>
         </div>
       </li>
@@ -30,6 +41,7 @@ class FilterListItem extends React.Component {
 FilterListItem.propTypes = {
   filter: React.PropTypes.string.isRequired,
   delete: React.PropTypes.func.isRequired,
+  edit: React.PropTypes.func.isRequired,
 }
 
 module.exports = FilterListItem

--- a/src/components/FilterListItem/FilterListItem.less
+++ b/src/components/FilterListItem/FilterListItem.less
@@ -2,6 +2,16 @@
   font-weight: bold;
 }
 
-.filter-list-item:nth-child(even) {
-  background-color: #f9f9f9;
+.filter-list-item {
+  .is-link {
+    text-decoration: none;
+
+    + .is-link {
+      margin-left: 5px;
+    }
+  }
+
+  &:nth-child(even) {
+    background-color: #f9f9f9;
+  }
 }

--- a/src/components/NewFilter/NewFilter.jsx
+++ b/src/components/NewFilter/NewFilter.jsx
@@ -1,5 +1,6 @@
 const React = require('react')
 const Filter = require('../../models/filter')
+const FilterHelp = require('../FilterHelp')
 
 class NewFilter extends React.Component {
   constructor() {
@@ -84,98 +85,7 @@ class NewFilter extends React.Component {
             >Cancel</button>
           </p>
         </form>
-        <h2 className="subtitle">Search Query Help</h2>
-        <ul className="search-query-help">
-          <li>
-            <code>type</code> &mdash; With this qualifier you can restrict the
-            search to issues (<code>issue</code>) or pull request
-            (<code>pr</code>) only.
-          </li>
-          <li>
-            <code>in</code> &mdash; Qualifies which fields are searched. With
-            this qualifier you can restrict the search to just the title
-            (<code>title</code>), body (<code>body</code>), comments
-            (<code>comments</code>), or any combination of these.
-          </li>
-          <li>
-            <code>author</code> &mdash; Finds issues or pull requests created
-            by a certain user.
-          </li>
-          <li>
-            <code>assignee</code> &mdash; Finds issues or pull requests that
-            are assigned to a certain user.
-          </li>
-          <li>
-            <code>mentions</code> &mdash; Finds issues or pull requests that
-            mention a certain user.
-          </li>
-          <li>
-            <code>commenter</code> &mdash; Finds issues or pull requests that
-            a certain user commented on.
-          </li>
-          <li>
-            <code>involves</code> &mdash; Finds issues or pull requests that
-            were either created by a certain user, assigned to that user,
-            mention that user, or were commented on by that user.
-          </li>
-          <li>
-            <code>team</code> &mdash; For organizations you're a member of,
-            finds issues or pull requests that @mention a team within the
-            organization.
-          </li>
-          <li>
-            <code>state</code> &mdash; Filter issues or pull requests based on
-            whether they're open or closed.
-          </li>
-          <li>
-            <code>labels</code> &mdash; Filters issues or pull requests based
-            on their labels.
-          </li>
-          <li>
-            <code>no</code> &mdash; Filters items missing certain metadata,
-            such as <code>label</code>, <code>milestone</code>, or
-            <code>assignee</code>.
-          </li>
-          <li>
-            <code>language</code> &mdash; Searches for issues or pull requests
-            within repositories that match a certain language.
-          </li>
-          <li>
-            <code>is</code> &mdash; Searches for items within repositories that
-            match a certain state, such as <code>open</code>,
-            <code>closed</code>, or <code>merged</code>
-          </li>
-          <li>
-            <code>created</code> or <code>updated</code> &mdash; Filters issues
-            or pull requests based on date of creation, or when they were last
-            updated.
-          </li>
-          <li>
-            <code>merged</code> &mdash; Filters pull requests based on the date
-            when they were merged.
-          </li>
-          <li>
-            <code>status</code> &mdash; Filters pull requests based on the
-            commit status.
-          </li>
-          <li>
-            <code>head</code> or <code>base</code> &mdash; Filters pull
-            requests based on the branch that they came from or that they are
-            modifying.
-          </li>
-          <li>
-            <code>closed</code> &mdash; Filters issues or pull requests based
-            on the date when they were closed.
-          </li>
-          <li>
-            <code>comments</code> &mdash; Filters issues or pull requests based
-            on the quantity of comments.
-          </li>
-          <li>
-            <code>user</code> or <code>repo</code> &mdash; Limits searches to a
-            specific user or repository.
-          </li>
-        </ul>
+        <FilterHelp />
       </div>
     )
   }

--- a/src/components/NewFilter/NewFilter.jsx
+++ b/src/components/NewFilter/NewFilter.jsx
@@ -36,12 +36,24 @@ class NewFilter extends React.Component {
       valueClass += ' is-danger'
     }
     return (
-      <div>
-        <h1 className="title">
-          <a href="#" onClick={event => this.cancel(event)}>Tasks</a>
-          <span> / </span>
-          Add a Filter
-        </h1>
+      <div className="new-filter-container">
+        <div className="columns new-filter-top-navigation">
+          <div className="column is-7">
+            <h1 className="title">
+              <a href="#" onClick={event => this.cancel(event)}>Tasks</a>
+              <span> / </span>
+              Add a Filter
+            </h1>
+          </div>
+          <div className="column is-5 has-text-right">
+            <button
+              onClick={this.props.manageFilters}
+              type="button"
+              className="is-link button"
+              title="Manage filters"
+            ><span className="octicon octicon-three-bars"></span></button>
+          </div>
+        </div>
         <form className="new-filter-form" onSubmit={event => this.save(event)}>
           <label className="label">Search query:</label>
           <p className="control">
@@ -172,6 +184,7 @@ class NewFilter extends React.Component {
 NewFilter.propTypes = {
   save: React.PropTypes.func.isRequired,
   cancel: React.PropTypes.func.isRequired,
+  manageFilters: React.PropTypes.func.isRequired,
 }
 
 module.exports = NewFilter

--- a/src/components/NewFilter/NewFilter.less
+++ b/src/components/NewFilter/NewFilter.less
@@ -1,3 +1,15 @@
 .new-filter-form {
   margin-bottom: 40px;
 }
+
+.new-filter-container {
+}
+
+.new-filter-top-navigation.columns {
+  border-bottom: 1px solid rgba(211, 214, 219, 0.5);
+  margin-bottom: 15px;
+
+  .is-link {
+    text-decoration: none;
+  }
+}

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -17,22 +17,25 @@ class TaskList extends React.Component {
   render() {
     return (
       <div>
-        <nav className="controls-container">
+        <nav className="controls-container has-text-right">
+          <label className="label">With selected:</label>
           <button
             type="button"
             onClick={e => this.onSnoozeClick(e)}
-            className="control button"
-          >
-            snooze
-          </button>
-          <button type="button" className="control button">ignore</button>
+            className="control button is-link"
+            title="Snooze selected"
+          >😴</button>
           <button
             type="button"
-            className="control button"
+            className="control button is-link"
             onClick={e => this.onArchiveClick(e)}
-          >
-            archive
-          </button>
+            title="Archive selected"
+          >📥</button>
+          <button
+            type="button"
+            className="control button is-link"
+            title="Ignore selected"
+          >❌</button>
         </nav>
         <ol className="task-list">
           {this.props.tasks.map(task =>

--- a/src/components/TaskList/TaskList.less
+++ b/src/components/TaskList/TaskList.less
@@ -1,8 +1,23 @@
 .controls-container {
-  text-align: right;
+  margin-bottom: 10px;
+
+  .label {
+    margin-right: 5px;
+    display: inline-block;
+    font-weight: 400;
+    color: #333;
+    line-height: 28px;
+    font-size: 14px;
+    cursor: default;
+  }
 
   .control {
     display: inline-block;
+    font-size: 24px;
+
+    &.is-link {
+      text-decoration: none;
+    }
 
     + .control {
       margin-left: 5px;

--- a/src/components/TopNavigation/TopNavigation.jsx
+++ b/src/components/TopNavigation/TopNavigation.jsx
@@ -16,7 +16,7 @@ class Filter extends React.Component {
     const rules = Filters.findAll()
     return (
       <div className="top-navigation columns">
-        <div className="column is-8">
+        <div className="column is-10">
           <label className="label" htmlFor="filters-menu">Filter:</label>
           <span className="select">
             <select id="filters-menu" onChange={event => this.changeFilter(event)}>
@@ -34,23 +34,19 @@ class Filter extends React.Component {
             <span className="octicon octicon-sync"></span>
           </button>
         </div>
-        <div className="column is-4 has-text-right">
+        <div className="column is-2 has-text-right">
           <button
             onClick={this.props.manageFilters}
             type="button"
             className="is-link button"
-          >
-            Manage filters
-            <span className="octicon octicon-chevron-down"></span>
-          </button>
+            title="Manage filters"
+          ><span className="octicon octicon-three-bars"></span></button>
           <button
             onClick={this.props.addFilter}
             type="button"
             className="is-link button"
-          >
-            Add a filter
-            <span className="octicon octicon-chevron-down"></span>
-          </button>
+            title="Add a filter"
+          ><span className="octicon octicon-plus"></span></button>
         </div>
       </div>
     )

--- a/src/components/TopNavigation/TopNavigation.jsx
+++ b/src/components/TopNavigation/TopNavigation.jsx
@@ -16,7 +16,7 @@ class Filter extends React.Component {
     const rules = Filters.findAll()
     return (
       <div className="top-navigation columns">
-        <div className="column is-6">
+        <div className="column is-8">
           <label className="label" htmlFor="filters-menu">Filter:</label>
           <span className="select">
             <select id="filters-menu" onChange={event => this.changeFilter(event)}>
@@ -34,7 +34,7 @@ class Filter extends React.Component {
             <span className="octicon octicon-sync"></span>
           </button>
         </div>
-        <div className="column is-6 has-text-right">
+        <div className="column is-4 has-text-right">
           <button
             onClick={this.props.manageFilters}
             type="button"

--- a/src/components/TopNavigation/TopNavigation.less
+++ b/src/components/TopNavigation/TopNavigation.less
@@ -1,15 +1,14 @@
-.top-navigation {
+.top-navigation.columns {
+  border-bottom: 1px solid rgba(211, 214, 219, 0.5);
+  margin-bottom: 15px;
+
   .label {
     display: inline-block;
     line-height: 32px;
     margin-right: 5px;
   }
 
-  .button.is-link {
+  .is-link {
     text-decoration: none;
-
-    .octicon {
-      margin-left: 5px;
-    }
   }
 }


### PR DESCRIPTION
This fixes #7 by allowing you to edit existing filters. It also makes the top navigation bar more consistent across each view. It also replaces the text on snooze/archive/ignore buttons with emoji.

![screen shot 2016-09-03 at 8 16 42 pm](https://cloud.githubusercontent.com/assets/82317/18228435/7f9b6242-7213-11e6-9eaa-aa6208f5c4fd.png)

![screen shot 2016-09-03 at 8 19 04 pm](https://cloud.githubusercontent.com/assets/82317/18228438/b33b8672-7213-11e6-8999-a1ffbd8c08f5.png)
![screen shot 2016-09-03 at 8 19 00 pm](https://cloud.githubusercontent.com/assets/82317/18228439/b33c9d96-7213-11e6-875d-89622d49bf10.png)
![screen shot 2016-09-03 at 8 18 56 pm](https://cloud.githubusercontent.com/assets/82317/18228437/b33b090e-7213-11e6-8b49-fa6cc0f67750.png)

/cc @probablycorey 
