### PR TITLE
Set newly created filters as LastFilter, update results accordingly

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -188,6 +188,7 @@ class App extends React.Component {
         save={() => this.savedFilter()}
         cancel={() => this.showTaskList()}
         manageFilters={() => this.manageFilters()}
+        loadFilter={key => this.loadFilter(key)}
       />
     )
   }

--- a/src/components/NewFilter/NewFilter.jsx
+++ b/src/components/NewFilter/NewFilter.jsx
@@ -2,6 +2,7 @@ const React = require('react')
 const Filter = require('../../models/Filter')
 const FilterHelp = require('../FilterHelp')
 const hookUpStickyNav = require('../hookUpStickyNav')
+const LastFilter = require('../../models/LastFilter')
 
 class NewFilter extends React.Component {
   constructor() {
@@ -24,6 +25,8 @@ class NewFilter extends React.Component {
     }
     const filter = new Filter(key)
     filter.store(value)
+    LastFilter.save(key)
+    this.props.loadFilter(key)
     this.props.save(key)
   }
 
@@ -77,7 +80,7 @@ class NewFilter extends React.Component {
               />
             </p>
             <p className="control">
-              <button type="submit" className="button is-primary">
+              <button type="submit" className="button is-primary" id="new-filter-save">
                 Save Filter
               </button>
               <button
@@ -98,6 +101,7 @@ NewFilter.propTypes = {
   save: React.PropTypes.func.isRequired,
   cancel: React.PropTypes.func.isRequired,
   manageFilters: React.PropTypes.func.isRequired,
+  loadFilter: React.PropTypes.func.isRequired,
 }
 
 module.exports = hookUpStickyNav(NewFilter, 'new-filter-top-navigation')

--- a/test/components/NewFilterTest.js
+++ b/test/components/NewFilterTest.js
@@ -1,15 +1,40 @@
 const assert = require('assert')
 const React = require('react')
 const ReactDOM = require('react-dom')
+const ReactRedux = require('react-redux')
+const Redux = require('redux')
+const fetchMock = require('fetch-mock')
 const TestUtils = require('react-addons-test-utils')
-const NewFilter = require('../../src/components/NewFilter/NewFilter.jsx')
+const NewFilter = require('../../src/components/NewFilter')
+const ElectronConfig = require('electron-config')
+const storage = new ElectronConfig({ name: 'config-test' })
+const reducer = require('../../src/reducers/reducer')
+
+function renderPage(store) {
+  // NewFilter calls loadFilter and save functions from the main App onSubmit.
+  return TestUtils.renderIntoDocument(
+    <ReactRedux.Provider store={store}>
+      <NewFilter
+        loadFilter={key => key}
+        save={() => 'saved'}
+      />
+    </ReactRedux.Provider>
+  )
+}
 
 describe('NewFilter', () => {
   let renderedDOM
+  let store
 
   before(() => {
-    const component = TestUtils.renderIntoDocument(<NewFilter />)
+    store = Redux.createStore(reducer)
+    fetchMock.mock('*', {})
+    const component = renderPage(store)
     renderedDOM = () => ReactDOM.findDOMNode(component)
+  })
+
+  after(() => {
+    fetchMock.restore()
   })
 
   it('shows the form', () => {
@@ -19,17 +44,24 @@ describe('NewFilter', () => {
 
   describe('Create', () => {
     it('has a save button', () => {
-      const saveButton = renderedDOM().querySelectorAll('#new-filter-save')
-      assert.equal(1, saveButton.length)
+      const saveButton = renderedDOM().querySelector('#new-filter-save')
+      assert(saveButton)
     })
 
     it('has required form fields', () => {
-      const valueInput = renderedDOM().querySelectorAll("input[name='filterValue']")
-      assert.equal(1, valueInput.length)
+      const valueInput = renderedDOM().querySelector("input[name='filterValue']")
+      assert(valueInput)
     })
 
-    xit('sets a created filter as LastFilter', () => {
+    it('sets a created filter as LastFilter', () => {
+      const filterForm = renderedDOM().querySelector('form.new-filter-form')
+      const valueInput = renderedDOM().querySelector("input[name='filterValue']")
+      const filter = 'author:LuluPopplewell'
 
+      valueInput.value = filter
+      TestUtils.Simulate.change(valueInput)
+      TestUtils.Simulate.submit(filterForm)
+      assert.equal(storage.get(filter), 'author:LuluPopplewell')
     })
   })
 })

--- a/test/components/NewFilterTest.js
+++ b/test/components/NewFilterTest.js
@@ -1,0 +1,35 @@
+const assert = require('assert')
+const React = require('react')
+const ReactDOM = require('react-dom')
+const TestUtils = require('react-addons-test-utils')
+const NewFilter = require('../../src/components/NewFilter/NewFilter.jsx')
+
+describe('NewFilter', () => {
+  let renderedDOM
+
+  before(() => {
+    const component = TestUtils.renderIntoDocument(<NewFilter />)
+    renderedDOM = () => ReactDOM.findDOMNode(component)
+  })
+
+  it('shows the form', () => {
+    const newFilterForm = renderedDOM().querySelectorAll('.new-filter-form')
+    assert.equal(1, newFilterForm.length)
+  })
+
+  describe('Create', () => {
+    it('has a save button', () => {
+      const saveButton = renderedDOM().querySelectorAll('#new-filter-save')
+      assert.equal(1, saveButton.length)
+    })
+
+    it('has required form fields', () => {
+      const valueInput = renderedDOM().querySelectorAll("input[name='filterValue']")
+      assert.equal(1, valueInput.length)
+    })
+
+    xit('sets a created filter as LastFilter', () => {
+
+    })
+  })
+})

--- a/test/components/NewFilterTest.js
+++ b/test/components/NewFilterTest.js
@@ -38,13 +38,13 @@ describe('NewFilter', () => {
   })
 
   it('shows the form', () => {
-    const newFilterForm = renderedDOM().querySelectorAll('.new-filter-form')
-    assert.equal(1, newFilterForm.length)
+    const newFilterForm = renderedDOM().querySelector('.new-filter-form')
+    assert(newFilterForm)
   })
 
   describe('Create', () => {
     it('has a save button', () => {
-      const saveButton = renderedDOM().querySelector('#new-filter-save')
+      const saveButton = renderedDOM().querySelector('button[type="submit"]')
       assert(saveButton)
     })
 
@@ -61,7 +61,8 @@ describe('NewFilter', () => {
       valueInput.value = filter
       TestUtils.Simulate.change(valueInput)
       TestUtils.Simulate.submit(filterForm)
-      assert.equal(storage.get(filter), 'author:LuluPopplewell')
+      assert.equal('author:LuluPopplewell', storage.get(filter))
+      assert.equal('author:LuluPopplewell', storage.get('last-filter'))
     })
   })
 })


### PR DESCRIPTION
Fixes #61 

When a new filter is created, sets it as the active filter and updates the Task List. 
