### PR TITLE
Disable buttons when none selected, remove horizontal scrollbars

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -90,6 +90,7 @@ class App extends React.Component {
           save={() => this.savedFilter()}
           cancel={() => this.showTaskList()}
           manageFilters={() => this.manageFilters()}
+          loadFilter={key => this.loadFilter(key)}
         />)
       case 'hidden': return (
         <HiddenTaskList

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -20,8 +20,9 @@ const HiddenTaskList = require('../HiddenTaskList')
 class App extends React.Component {
   constructor() {
     super()
+    const view = GitHubAuth.isAuthenticated() ? 'tasks' : 'auth'
     this.state = {
-      view: 'tasks',
+      view,
       filters: Filters.findAll(),
       filter: LastFilter.retrieve(),
     }
@@ -41,8 +42,10 @@ class App extends React.Component {
   }
 
   onUserLoad(user) {
-    const filters = new DefaultFilters(user.login)
-    filters.addDefaults()
+    if (user) {
+      const filters = new DefaultFilters(user.login)
+      filters.addDefaults()
+    }
     this.setState({ user, filters: Filters.findAll() })
   }
 
@@ -97,7 +100,6 @@ class App extends React.Component {
           cancel={() => this.showTaskList()}
           activeFilter={this.state.filter}
         />)
-      // Auth is default to ensure token
       default: return (
         <Auth
           done={user => this.finishedWithAuth(user)}
@@ -194,7 +196,9 @@ class App extends React.Component {
 
   finishedWithAuth(user) {
     this.onUserLoad(user)
-    this.showTaskList()
+    if (user) {
+      this.showTaskList()
+    }
   }
 
   render() {
@@ -207,6 +211,7 @@ class App extends React.Component {
           showAuth={() => this.showAuth()}
           showTasks={() => this.showTaskList()}
           active={this.state.view}
+          isAuthenticated={GitHubAuth.isAuthenticated()}
         />
         {this.getViewContents()}
       </div>)

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #ffF;
+  background-color: #fffFFf;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #fffFFf;
+  background-color: #fFfFFf;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #fff;
+  background-color: #FFF;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -21,13 +21,45 @@ body {
   margin-right: 5px;
 }
 
-.top-nav, .secondary-nav {
+.top-nav, .secondary-nav, .tertiary-nav {
   z-index: 5;
   margin-bottom: 15px;
   border-bottom: 1px solid rgba(211, 214, 219, 0.5);
 
   .button.is-link, .label {
     text-decoration: none;
+  }
+
+  .nav-item {
+    padding: 5px 10px;
+  }
+}
+
+.nav-item.compact-vertically {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.secondary-nav.has-tertiary-nav {
+  margin-bottom: 0;
+  border-bottom: 0;
+  min-height: 38px;
+
+  .nav-item {
+    align-items: flex-end;
+  }
+}
+
+.tertiary-nav {
+  min-height: 0;
+
+  .nav-item {
+    align-items: flex-start;
+  }
+
+  .compact-vertically .is-small {
+    line-height: 14px;
+    height: 22px;
   }
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #FFF;
+  background-color: #ffF;
   min-height: 100vh;
 }
 
@@ -68,28 +68,6 @@ body {
   .compact-vertically .is-small {
     line-height: 14px;
     height: 22px;
-  }
-}
-
-nav#tabbed-nav.tabs.is-toggle {
-  margin-bottom: 0;
-  min-height: 0;
-
-  li a {
-    border-top: 0;
-  }
-
-  li:first-child a,
-  li:last-child a {
-    border-radius: 0;
-  }
-
-  li:first-child a {
-    border-left: 0;
-  }
-
-  li:last-child a {
-    border-right: 0;
   }
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -23,8 +23,6 @@ body {
 
 .top-nav, .secondary-nav, .tertiary-nav {
   z-index: 5;
-  margin-bottom: 15px;
-  border-bottom: 1px solid rgba(211, 214, 219, 0.5);
 
   .button.is-link, .label {
     text-decoration: none;
@@ -40,18 +38,28 @@ body {
   padding-bottom: 0;
 }
 
-.secondary-nav.has-tertiary-nav {
-  margin-bottom: 0;
-  border-bottom: 0;
+.nav {
   min-height: 38px;
+}
 
-  .nav-item {
-    align-items: flex-end;
+.secondary-nav {
+  border-bottom: 1px solid rgba(211, 214, 219, 0.5);
+  margin-bottom: 15px;
+
+  &.has-tertiary-nav {
+    border-bottom: 0;
+    margin-bottom: 0;
+
+    .nav-item {
+      align-items: flex-end;
+    }
   }
 }
 
 .tertiary-nav {
   min-height: 0;
+  border-bottom: 1px solid rgba(211, 214, 219, 0.5);
+  margin-bottom: 15px;
 
   .nav-item {
     align-items: flex-start;

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -71,8 +71,26 @@ body {
   }
 }
 
-nav#tabbed-nav {
+nav#tabbed-nav.tabs.is-toggle {
   margin-bottom: 0;
+  min-height: 0;
+
+  li a {
+    border-top: 0;
+  }
+
+  li:first-child a,
+  li:last-child a {
+    border-radius: 0;
+  }
+
+  li:first-child a {
+    border-left: 0;
+  }
+
+  li:last-child a {
+    border-right: 0;
+  }
 }
 
 .octicon {

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -91,19 +91,22 @@ class Auth extends React.Component {
       return ''
     }
     return (
-      <p className="notification is-success">
-        You are
-        {typeof this.props.user === 'object' ? (
-          <span> authenticated as
-            <strong> {this.props.user.login}</strong>.
-            <span> </span>
-            <a
-              href="#"
-              onClick={event => this.deleteToken(event)}
-            >Log out</a>
-          </span>
-        ) : ' authenticated.'}
-      </p>
+      <div>
+        <p className="content">
+          You are
+          {typeof this.props.user === 'object' ? (
+            <span> authenticated as
+              <strong> {this.props.user.login}</strong>.
+              <span> </span>
+              <a
+                href="#"
+                onClick={event => this.deleteToken(event)}
+              >Log out</a>
+            </span>
+          ) : ' authenticated.'}
+        </p>
+        <hr />
+      </div>
     )
   }
 
@@ -136,6 +139,7 @@ class Auth extends React.Component {
       <div>
         <div className="view-container">
           {this.authSuccessMessage()}
+          <h2 className="subtitle">Set Access Token</h2>
           <form className="auth-form" onSubmit={event => this.save(event)}>
             {this.tokenErrorMessage()}
             <p className="control">
@@ -182,7 +186,7 @@ class Auth extends React.Component {
               ) : ''}
             </p>
             <hr />
-            <h2 className="subtitle">Token Scope</h2>
+            <h2 className="subtitle">Token Scope Help</h2>
             <p>
               <img
                 className="scope-screenshot"

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -3,7 +3,6 @@ const shell = require('electron').shell
 
 const GitHubAuth = require('../../models/GitHubAuth')
 const GitHub = require('../../models/GitHub')
-const hookUpStickyNav = require('../hookUpStickyNav')
 
 class Auth extends React.Component {
   constructor() {
@@ -204,4 +203,4 @@ Auth.propTypes = {
   user: React.PropTypes.object,
 }
 
-module.exports = hookUpStickyNav(Auth, 'auth-top-navigation')
+module.exports = Auth

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -135,13 +135,15 @@ class Auth extends React.Component {
       <div>
         <nav id="auth-navigation" className="secondary-nav nav">
           <div className="nav-right">
-            <button
-              className="button is-link"
-              title="Sign out"
-              type="button"
-              onClick={event => this.deleteToken(event)}
-              disabled={!this.props.isAuthenticated}
-            >🔌 Log out</button>
+            <span className="nav-item">
+              <button
+                className="button is-link"
+                title="Sign out"
+                type="button"
+                onClick={event => this.deleteToken(event)}
+                disabled={!this.props.isAuthenticated}
+              >🔌 Log out</button>
+            </span>
           </div>
         </nav>
         <div className="view-container">

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -87,25 +87,6 @@ class Auth extends React.Component {
     this.props.done()
   }
 
-  authSuccessMessage() {
-    if (!this.props.isAuthenticated) {
-      return ''
-    }
-    return (
-      <div>
-        <p className="content">
-          You are
-          {typeof this.props.user === 'object' ? (
-            <span> authenticated as
-              <strong> {this.props.user.login}</strong>.
-            </span>
-          ) : ' authenticated.'}
-        </p>
-        <hr />
-      </div>
-    )
-  }
-
   tokenErrorMessage() {
     if (!this.state.tokenHasError) {
       return ''
@@ -134,6 +115,13 @@ class Auth extends React.Component {
     return (
       <div>
         <nav id="auth-navigation" className="secondary-nav nav">
+          {this.props.isAuthenticated && typeof this.props.user === 'object' ? (
+            <div className="nav-left">
+              <span className="nav-item">
+                Signed in as <strong>&nbsp;{this.props.user.login}</strong>
+              </span>
+            </div>
+          ) : ''}
           <div className="nav-right">
             <span className="nav-item">
               <button
@@ -147,7 +135,6 @@ class Auth extends React.Component {
           </div>
         </nav>
         <div className="view-container">
-          {this.authSuccessMessage()}
           <h2 className="subtitle">
             <span>{this.props.isAuthenticated ? 'Change' : 'Set'} </span>
             Access Token

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -2,6 +2,7 @@ const React = require('react')
 const shell = require('electron').shell
 
 const GitHubAuth = require('../../models/GitHubAuth')
+const hookUpStickyNav = require('../hookUpStickyNav')
 const GitHub = require('../../models/GitHub')
 
 class Auth extends React.Component {
@@ -97,11 +98,6 @@ class Auth extends React.Component {
           {typeof this.props.user === 'object' ? (
             <span> authenticated as
               <strong> {this.props.user.login}</strong>.
-              <span> </span>
-              <a
-                href="#"
-                onClick={event => this.deleteToken(event)}
-              >Log out</a>
             </span>
           ) : ' authenticated.'}
         </p>
@@ -137,9 +133,23 @@ class Auth extends React.Component {
     const authFile = GitHubAuth.path()
     return (
       <div>
+        <nav id="auth-navigation" className="secondary-nav nav">
+          <div className="nav-right">
+            <button
+              className="button is-link"
+              title="Sign out"
+              type="button"
+              onClick={event => this.deleteToken(event)}
+              disabled={!this.props.isAuthenticated}
+            >🔌 Log out</button>
+          </div>
+        </nav>
         <div className="view-container">
           {this.authSuccessMessage()}
-          <h2 className="subtitle">Set Access Token</h2>
+          <h2 className="subtitle">
+            <span>{this.props.isAuthenticated ? 'Change' : 'Set'} </span>
+            Access Token
+          </h2>
           <form className="auth-form" onSubmit={event => this.save(event)}>
             {this.tokenErrorMessage()}
             <p className="control">
@@ -207,4 +217,4 @@ Auth.propTypes = {
   user: React.PropTypes.object,
 }
 
-module.exports = Auth
+module.exports = hookUpStickyNav(Auth, '#auth-navigation')

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -2,8 +2,8 @@ const React = require('react')
 const shell = require('electron').shell
 
 const GitHubAuth = require('../../models/GitHubAuth')
-const hookUpStickyNav = require('../hookUpStickyNav')
 const GitHub = require('../../models/GitHub')
+const hookUpStickyNav = require('../hookUpStickyNav')
 
 class Auth extends React.Component {
   constructor() {
@@ -114,7 +114,7 @@ class Auth extends React.Component {
     const authFile = GitHubAuth.path()
     return (
       <div>
-        <nav id="auth-navigation" className="secondary-nav nav">
+        <nav id="auth-top-navigation" className="secondary-nav nav">
           {this.props.isAuthenticated && typeof this.props.user === 'object' ? (
             <div className="nav-left">
               <span className="nav-item">
@@ -206,4 +206,4 @@ Auth.propTypes = {
   user: React.PropTypes.object,
 }
 
-module.exports = hookUpStickyNav(Auth, '#auth-navigation')
+module.exports = hookUpStickyNav(Auth, '#auth-top-navigation')

--- a/src/components/Auth/Auth.less
+++ b/src/components/Auth/Auth.less
@@ -1,7 +1,3 @@
-#auth-top-navigation {
-  padding: 20px 20px 15px 20px;
-}
-
 .help code {
   font-size: inherit;
 }

--- a/src/components/EditFilter/EditFilter.jsx
+++ b/src/components/EditFilter/EditFilter.jsx
@@ -1,6 +1,7 @@
 const React = require('react')
 const Filter = require('../../models/Filter')
 const FilterHelp = require('../FilterHelp')
+const hookUpStickyNav = require('../hookUpStickyNav')
 
 class EditFilter extends React.Component {
   constructor(props) {
@@ -52,6 +53,13 @@ class EditFilter extends React.Component {
     }
     return (
       <div>
+        <nav className="nav secondary-nav" id="edit-filter-top-navigation">
+          <div className="nav-left">
+            <h2 className="subtitle nav-item">
+              Edit Filter
+            </h2>
+          </div>
+        </nav>
         <div className="view-container">
           <form className="edit-filter-form" onSubmit={event => this.save(event)}>
             <label className="label">Search query:</label>
@@ -102,4 +110,4 @@ EditFilter.propTypes = {
   delete: React.PropTypes.func.isRequired,
 }
 
-module.exports = EditFilter
+module.exports = hookUpStickyNav(EditFilter, '#edit-filter-top-navigation')

--- a/src/components/EditFilter/EditFilter.jsx
+++ b/src/components/EditFilter/EditFilter.jsx
@@ -1,7 +1,6 @@
 const React = require('react')
 const Filter = require('../../models/Filter')
 const FilterHelp = require('../FilterHelp')
-const hookUpStickyNav = require('../hookUpStickyNav')
 
 class EditFilter extends React.Component {
   constructor(props) {
@@ -103,4 +102,4 @@ EditFilter.propTypes = {
   delete: React.PropTypes.func.isRequired,
 }
 
-module.exports = hookUpStickyNav(EditFilter, 'edit-filter-top-navigation')
+module.exports = EditFilter

--- a/src/components/EditFilter/EditFilter.less
+++ b/src/components/EditFilter/EditFilter.less
@@ -1,7 +1,3 @@
 .edit-filter-form {
   margin-bottom: 40px;
 }
-
-#edit-filter-top-navigation {
-  padding: 20px 20px 15px 20px;
-}

--- a/src/components/FilterList/FilterList.jsx
+++ b/src/components/FilterList/FilterList.jsx
@@ -66,4 +66,4 @@ FilterList.propTypes = {
   cancel: React.PropTypes.func.isRequired,
 }
 
-module.exports = hookUpStickyNav(FilterList, 'filter-list-top-navigation')
+module.exports = hookUpStickyNav(FilterList, '#filter-list-top-navigation')

--- a/src/components/FilterList/FilterList.jsx
+++ b/src/components/FilterList/FilterList.jsx
@@ -36,6 +36,9 @@ class FilterList extends React.Component {
       <div>
         <nav className="nav secondary-nav" id="filter-list-top-navigation">
           <div className="nav-left">
+            <h2 className="subtitle nav-item">
+              Manage Filters
+            </h2>
           </div>
           <div className="nav-right">
             <span className="nav-item">

--- a/src/components/HiddenTaskList/HiddenTaskList.jsx
+++ b/src/components/HiddenTaskList/HiddenTaskList.jsx
@@ -83,5 +83,5 @@ HiddenTaskList.propTypes = {
 const mapStateToProps = state => ({ tasks: state.tasks })
 
 const stickyNavd = hookUpStickyNav(HiddenTaskList,
-                                   'hidden-task-list-navigation')
+                                   '#hidden-task-list-navigation')
 module.exports = connect(mapStateToProps)(stickyNavd)

--- a/src/components/HiddenTaskList/HiddenTaskList.jsx
+++ b/src/components/HiddenTaskList/HiddenTaskList.jsx
@@ -38,21 +38,22 @@ class HiddenTaskList extends React.Component {
       <div>
         <nav id="hidden-task-list-navigation" className="secondary-nav nav">
           <div className="nav-left">
-            <h1 className="title">
-              Hidden Tasks
-              <span className="subtitle"> in &ldquo;{activeFilter}&rdquo;</span>
-            </h1>
+            <h2 className="subtitle nav-item">
+              Hidden Tasks in &ldquo;{activeFilter}&rdquo;
+            </h2>
           </div>
           {hiddenTasks.length < 1 ? '' : (
             <div className="nav-right">
-              <button
-                type="button"
-                onClick={e => this.onRestoreClick(e)}
-                className="control button is-link"
-                id="restore-button"
-                title="Restore selected"
-                disabled={isRestoreDisabled}
-              >↩️ Restore</button>
+              <span className="nav-item">
+                <button
+                  type="button"
+                  onClick={e => this.onRestoreClick(e)}
+                  className="control button is-link"
+                  id="restore-button"
+                  title="Restore selected"
+                  disabled={isRestoreDisabled}
+                >↩️ Restore</button>
+              </span>
             </div>
           )}
         </nav>

--- a/src/components/HiddenTaskList/HiddenTaskList.jsx
+++ b/src/components/HiddenTaskList/HiddenTaskList.jsx
@@ -56,7 +56,7 @@ class HiddenTaskList extends React.Component {
             </div>
           )}
         </nav>
-        <div className="hidden-task-list-container">
+        <div className="view-container">
           {this.emptyListMessage(hiddenTasks)}
           <ol className="task-list">
             {hiddenTasks.map(task =>

--- a/src/components/HiddenTaskList/HiddenTaskList.jsx
+++ b/src/components/HiddenTaskList/HiddenTaskList.jsx
@@ -16,24 +16,6 @@ class HiddenTaskList extends React.Component {
     this.props.cancel()
   }
 
-  navigation(tasks) {
-    if (tasks.length < 1) {
-      return
-    }
-    return (
-      <nav className="controls-container has-text-right">
-        <label className="label">With selected:</label>
-        <button
-          type="button"
-          onClick={e => this.onRestoreClick(e)}
-          className="control button is-link"
-          id="restore-button"
-          title="Restore selected"
-        >↩️</button>
-      </nav>
-    )
-  }
-
   emptyListMessage(tasks) {
     if (tasks.length > 0) {
       return
@@ -48,7 +30,10 @@ class HiddenTaskList extends React.Component {
 
   render() {
     const { activeFilter } = this.props
-    const hiddenTasks = this.props.tasks.filter(task => TaskVisibility.isHiddenTask(task))
+    const hiddenTasks = this.props.tasks.
+        filter(task => TaskVisibility.isHiddenTask(task))
+    const isRestoreDisabled = hiddenTasks.
+        filter(task => task.isSelected).length < 1
     return (
       <div>
         <nav id="hidden-task-list-navigation" className="secondary-nav nav">
@@ -58,9 +43,20 @@ class HiddenTaskList extends React.Component {
               <span className="subtitle"> in &ldquo;{activeFilter}&rdquo;</span>
             </h1>
           </div>
+          {hiddenTasks.length < 1 ? '' : (
+            <div className="nav-right">
+              <button
+                type="button"
+                onClick={e => this.onRestoreClick(e)}
+                className="control button is-link"
+                id="restore-button"
+                title="Restore selected"
+                disabled={isRestoreDisabled}
+              >↩️ Restore</button>
+            </div>
+          )}
         </nav>
         <div className="hidden-task-list-container">
-          {this.navigation(hiddenTasks)}
           {this.emptyListMessage(hiddenTasks)}
           <ol className="task-list">
             {hiddenTasks.map(task =>

--- a/src/components/HiddenTaskList/HiddenTaskList.less
+++ b/src/components/HiddenTaskList/HiddenTaskList.less
@@ -1,3 +1,0 @@
-#hidden-task-list-navigation {
-  padding: 20px 20px 15px 20px;
-}

--- a/src/components/HiddenTaskList/HiddenTaskList.less
+++ b/src/components/HiddenTaskList/HiddenTaskList.less
@@ -1,7 +1,3 @@
-.hidden-task-list-container {
-  padding: 0 20px 20px 20px;
-}
-
 #hidden-task-list-navigation {
   padding: 20px 20px 15px 20px;
 }

--- a/src/components/NewFilter/NewFilter.jsx
+++ b/src/components/NewFilter/NewFilter.jsx
@@ -2,6 +2,7 @@ const React = require('react')
 const Filter = require('../../models/Filter')
 const FilterHelp = require('../FilterHelp')
 const LastFilter = require('../../models/LastFilter')
+const hookUpStickyNav = require('../hookUpStickyNav')
 
 class NewFilter extends React.Component {
   constructor() {
@@ -41,6 +42,13 @@ class NewFilter extends React.Component {
     }
     return (
       <div>
+        <nav className="nav secondary-nav" id="new-filter-top-navigation">
+          <div className="nav-left">
+            <h2 className="subtitle nav-item">
+              New Filter
+            </h2>
+          </div>
+        </nav>
         <div className="view-container">
           <form className="new-filter-form" onSubmit={event => this.save(event)}>
             <label className="label">Search query:</label>
@@ -86,4 +94,4 @@ NewFilter.propTypes = {
   loadFilter: React.PropTypes.func.isRequired,
 }
 
-module.exports = NewFilter
+module.exports = hookUpStickyNav(NewFilter, '#new-filter-top-navigation')

--- a/src/components/NewFilter/NewFilter.jsx
+++ b/src/components/NewFilter/NewFilter.jsx
@@ -1,7 +1,6 @@
 const React = require('react')
 const Filter = require('../../models/Filter')
 const FilterHelp = require('../FilterHelp')
-const hookUpStickyNav = require('../hookUpStickyNav')
 const LastFilter = require('../../models/LastFilter')
 
 class NewFilter extends React.Component {
@@ -87,4 +86,4 @@ NewFilter.propTypes = {
   loadFilter: React.PropTypes.func.isRequired,
 }
 
-module.exports = hookUpStickyNav(NewFilter, 'new-filter-top-navigation')
+module.exports = NewFilter

--- a/src/components/NewFilter/NewFilter.less
+++ b/src/components/NewFilter/NewFilter.less
@@ -1,7 +1,3 @@
 .new-filter-form {
   margin-bottom: 40px;
 }
-
-#new-filter-top-navigation {
-  padding: 20px 20px 15px 20px;
-}

--- a/src/components/TabbedNav/TabbedNav.jsx
+++ b/src/components/TabbedNav/TabbedNav.jsx
@@ -39,4 +39,4 @@ TabbedNav.propTypes = {
   active: React.PropTypes.string,
 }
 
-module.exports = hookUpStickyNav(TabbedNav, 'tabbed-nav')
+module.exports = hookUpStickyNav(TabbedNav, '#tabbed-nav')

--- a/src/components/TabbedNav/TabbedNav.jsx
+++ b/src/components/TabbedNav/TabbedNav.jsx
@@ -2,6 +2,11 @@ const React = require('react')
 const hookUpStickyNav = require('../hookUpStickyNav')
 
 class TabbedNav extends React.Component {
+  isTasksActive() {
+    const taskViews = ['tasks', 'hidden']
+    return taskViews.indexOf(this.props.active) > -1
+  }
+
   isFiltersActive() {
     const filterViews = ['filters', 'new-filter', 'edit-filter']
     return filterViews.indexOf(this.props.active) > -1
@@ -12,7 +17,7 @@ class TabbedNav extends React.Component {
     return (
       <nav id="tabbed-nav" className="top-nav nav tabs is-toggle is-fullwidth">
         <ul>
-          <li className={active === 'tasks' ? 'is-active' : ''}>
+          <li className={this.isTasksActive() ? 'is-active' : ''}>
             <button
               id="notifications-link"
               onClick={this.props.showTasks}

--- a/src/components/TabbedNav/TabbedNav.jsx
+++ b/src/components/TabbedNav/TabbedNav.jsx
@@ -2,6 +2,11 @@ const React = require('react')
 const hookUpStickyNav = require('../hookUpStickyNav')
 
 class TabbedNav extends React.Component {
+  isFiltersActive() {
+    const filterViews = ['filters', 'new-filter', 'edit-filter']
+    return filterViews.indexOf(this.props.active) > -1
+  }
+
   render() {
     const { active, user, isAuthenticated } = this.props
     return (
@@ -18,7 +23,7 @@ class TabbedNav extends React.Component {
               <span>Tasks</span>
             </button>
           </li>
-          <li className={active === 'filters' ? 'is-active' : ''}>
+          <li className={this.isFiltersActive() ? 'is-active' : ''}>
             <button
               id="filters-link"
               onClick={this.props.manageFilters}

--- a/src/components/TabbedNav/TabbedNav.jsx
+++ b/src/components/TabbedNav/TabbedNav.jsx
@@ -3,25 +3,26 @@ const hookUpStickyNav = require('../hookUpStickyNav')
 
 class TabbedNav extends React.Component {
   render() {
+    const { active, user } = this.props
     return (
       <nav id="tabbed-nav" className="top-nav nav tabs is-toggle is-fullwidth">
         <ul>
-          <li className={this.props.active === 'tasks' ? 'is-active' : ''}>
+          <li className={active === 'tasks' ? 'is-active' : ''}>
             <a id="notifications-link" onClick={this.props.showTasks}>
               <span className="tab octicon octicon-mail"></span>
               <span>Tasks</span>
             </a>
           </li>
-          <li className={this.props.active === 'filters' ? 'is-active' : ''}>
+          <li className={active === 'filters' ? 'is-active' : ''}>
             <a id="filters-link" onClick={this.props.manageFilters}>
               <span className="tab octicon octicon-beaker"></span><span>Filters</span>
             </a>
           </li>
-          <li className={this.props.active === 'auth' ? 'is-active' : ''}>
-            {typeof this.props.user === 'object' ? (
+          <li className={active === 'auth' ? 'is-active' : ''}>
+            {typeof user === 'object' ? (
               <a id="auth-link" onClick={this.props.showAuth}>
                 <span className="tab octicon octicon-mark-github"></span>
-                <span className="user-login">{this.props.user.login}</span>
+                <span className="user-login">{user.login}</span>
               </a>
             ) : ''}
           </li>

--- a/src/components/TabbedNav/TabbedNav.jsx
+++ b/src/components/TabbedNav/TabbedNav.jsx
@@ -3,28 +3,45 @@ const hookUpStickyNav = require('../hookUpStickyNav')
 
 class TabbedNav extends React.Component {
   render() {
-    const { active, user } = this.props
+    const { active, user, isAuthenticated } = this.props
     return (
       <nav id="tabbed-nav" className="top-nav nav tabs is-toggle is-fullwidth">
         <ul>
           <li className={active === 'tasks' ? 'is-active' : ''}>
-            <a id="notifications-link" onClick={this.props.showTasks}>
+            <button
+              id="notifications-link"
+              onClick={this.props.showTasks}
+              className="button is-link"
+              disabled={!isAuthenticated}
+            >
               <span className="tab octicon octicon-mail"></span>
               <span>Tasks</span>
-            </a>
+            </button>
           </li>
           <li className={active === 'filters' ? 'is-active' : ''}>
-            <a id="filters-link" onClick={this.props.manageFilters}>
-              <span className="tab octicon octicon-beaker"></span><span>Filters</span>
-            </a>
+            <button
+              id="filters-link"
+              onClick={this.props.manageFilters}
+              className="button is-link"
+              disabled={!isAuthenticated}
+            >
+              <span className="tab octicon octicon-beaker"></span>
+              <span>Filters</span>
+            </button>
           </li>
           <li className={active === 'auth' ? 'is-active' : ''}>
-            {typeof user === 'object' ? (
-              <a id="auth-link" onClick={this.props.showAuth}>
-                <span className="tab octicon octicon-mark-github"></span>
-                <span className="user-login">{user.login}</span>
-              </a>
-            ) : ''}
+            <button
+              id="auth-link"
+              onClick={this.props.showAuth}
+              className="button is-link"
+            >
+              {typeof user === 'object' ? (
+                <span>
+                  <span className="tab octicon octicon-mark-github"></span>
+                  <span className="user-login">{user.login}</span>
+                </span>
+              ) : 'Authenticate'}
+            </button>
           </li>
         </ul>
       </nav>
@@ -38,6 +55,7 @@ TabbedNav.propTypes = {
   showAuth: React.PropTypes.func.isRequired,
   showTasks: React.PropTypes.func.isRequired,
   active: React.PropTypes.string,
+  isAuthenticated: React.PropTypes.bool.isRequired,
 }
 
 module.exports = hookUpStickyNav(TabbedNav, '#tabbed-nav')

--- a/src/components/TabbedNav/TabbedNav.less
+++ b/src/components/TabbedNav/TabbedNav.less
@@ -1,3 +1,35 @@
 .tab {
   padding-right: 5px;
 }
+
+nav#tabbed-nav.tabs.is-toggle {
+  margin-bottom: 0;
+  min-height: 0;
+
+  li.is-active .is-link {
+    background-color: #1fc8db;
+    border-color: #1fc8db;
+    color: white;
+    z-index: 1;
+  }
+
+  li .is-link {
+    width: 100%;
+    border: 1px solid #d3d6db;
+    margin-bottom: 0;
+    padding-bottom: 5px;
+    position: relative;
+  }
+
+  li .button {
+    border-radius: 0;
+  }
+
+  li:first-child .button {
+    border-left: 0;
+  }
+
+  li:last-child .button {
+    border-right: 0;
+  }
+}

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -42,7 +42,7 @@ class TaskList extends React.Component {
     const lastFilterKey = LastFilter.retrieve()
     const visibleTasks = this.props.tasks.
         filter(task => TaskVisibility.isVisibleTask(task))
-    const isSnoozeDisabled = this.props.tasks.
+    const isSnoozeDisabled = visibleTasks.
         filter(task => task.isSelected).length < 1
     const isArchiveDisabled = isSnoozeDisabled
     const isIgnoreDisabled = isSnoozeDisabled

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -48,9 +48,9 @@ class TaskList extends React.Component {
     const isIgnoreDisabled = isSnoozeDisabled
     return (
       <div>
-        <nav id="task-list-navigation" className="secondary-nav nav">
+        <nav className="task-list-navigation secondary-nav nav has-tertiary-nav">
           <div className="nav-left">
-            <span className="nav-item">
+            <span className="nav-item compact-vertically">
               <span className="select">
                 <select
                   id="filters-menu"
@@ -63,26 +63,16 @@ class TaskList extends React.Component {
                   ))}
                 </select>
               </span>
-            </span>
-            <span className="nav-item">
               <button
                 onClick={e => this.refresh(e)}
                 type="button"
                 title="Refresh list"
                 className="is-link button"
-              ><span className="octicon octicon-sync"></span></button>
-            </span>
-            <span className="nav-item">
-              <button
-                onClick={() => this.props.showHidden()}
-                type="button"
-                className="is-link button"
-                title="Show hidden tasks"
-              ><span className="octicon octicon-eye"></span></button>
+              >🔄</button>
             </span>
           </div>
           <div className="nav-right">
-            <span className="nav-item">
+            <span className="nav-item compact-vertically">
               <button
                 type="button"
                 onClick={e => this.onSnoozeClick(e)}
@@ -92,7 +82,7 @@ class TaskList extends React.Component {
                 disabled={isSnoozeDisabled}
               >😴 Snooze</button>
             </span>
-            <span className="nav-item">
+            <span className="nav-item compact-vertically">
               <button
                 type="button"
                 id="archive-button"
@@ -102,7 +92,7 @@ class TaskList extends React.Component {
                 disabled={isArchiveDisabled}
               >📥 Archive</button>
             </span>
-            <span className="nav-item">
+            <span className="nav-item compact-vertically">
               <button
                 type="button"
                 className="control button is-link"
@@ -110,6 +100,18 @@ class TaskList extends React.Component {
                 title="Ignore selected"
                 disabled={isIgnoreDisabled}
               >❌ Ignore</button>
+            </span>
+          </div>
+        </nav>
+        <nav className="task-list-navigation tertiary-nav nav">
+          <div className="nav-left">
+            <span className="nav-item compact-vertically">
+              <button
+                onClick={() => this.props.showHidden()}
+                type="button"
+                className="is-link is-small button"
+                title="Show hidden tasks"
+              >View hidden</button>
             </span>
           </div>
         </nav>
@@ -138,4 +140,4 @@ TaskList.propTypes = {
   showHidden: React.PropTypes.func.isRequired,
 }
 
-module.exports = connect(mapStateToProps)(hookUpStickyNav(TaskList, 'task-list-navigation'))
+module.exports = connect(mapStateToProps)(hookUpStickyNav(TaskList, '.task-list-navigation'))

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -78,9 +78,6 @@ class TaskList extends React.Component {
           </div>
           <div className="nav-right">
             <span className="nav-item">
-              <label className="label">With selected:</label>
-            </span>
-            <span className="nav-item">
               <button
                 type="button"
                 onClick={e => this.onSnoozeClick(e)}

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -40,7 +40,12 @@ class TaskList extends React.Component {
   render() {
     const filters = Filters.findAll()
     const lastFilterKey = LastFilter.retrieve()
-    const visibleTasks = this.props.tasks.filter(task => TaskVisibility.isVisibleTask(task))
+    const visibleTasks = this.props.tasks.
+        filter(task => TaskVisibility.isVisibleTask(task))
+    const isSnoozeDisabled = this.props.tasks.
+        filter(task => task.isSelected).length < 1
+    const isArchiveDisabled = isSnoozeDisabled
+    const isIgnoreDisabled = isSnoozeDisabled
     return (
       <div>
         <nav id="task-list-navigation" className="secondary-nav nav">
@@ -84,6 +89,7 @@ class TaskList extends React.Component {
                 className="control button is-link"
                 id="snooze-button"
                 title="Snooze selected"
+                disabled={isSnoozeDisabled}
               >😴 Snooze</button>
             </span>
             <span className="nav-item">
@@ -93,6 +99,7 @@ class TaskList extends React.Component {
                 className="control button is-link"
                 onClick={e => this.onArchiveClick(e)}
                 title="Archive selected"
+                disabled={isArchiveDisabled}
               >📥 Archive</button>
             </span>
             <span className="nav-item">
@@ -101,6 +108,7 @@ class TaskList extends React.Component {
                 className="control button is-link"
                 onClick={e => this.onIgnoreClick(e)}
                 title="Ignore selected"
+                disabled={isIgnoreDisabled}
               >❌ Ignore</button>
             </span>
           </div>

--- a/src/components/hookUpStickyNav/hookUpStickyNav.jsx
+++ b/src/components/hookUpStickyNav/hookUpStickyNav.jsx
@@ -1,6 +1,6 @@
 const React = require('react')
 
-function hookUpStickyNav(Component, navID) {
+function hookUpStickyNav(Component, navSelector) {
   class StickyNav extends React.Component {
     componentDidMount() {
       window.addEventListener('scroll', this.handleScroll)
@@ -13,9 +13,12 @@ function hookUpStickyNav(Component, navID) {
     handleScroll() {
       const doc = document.documentElement
       const top = (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0)
-      const nav = document.getElementById(navID)
-      nav.style.top = `${top}px`
-      nav.classList.toggle('has-shadow', top > 0)
+      const navBars = Array.from(document.querySelectorAll(navSelector))
+      navBars.forEach(navBar => {
+        const nav = navBar
+        nav.style.top = `${top}px`
+        nav.classList.toggle('has-shadow', top > 0)
+      })
     }
 
     render() {

--- a/test/components/TabbedNavTest.js
+++ b/test/components/TabbedNavTest.js
@@ -24,9 +24,15 @@ describe('TabbedNav', () => {
       assert(filtersLink, 'Should have a filters link')
     })
 
-    it('has no auth link', () => {
-      const authLinks = renderedDOM().querySelectorAll('#auth-link')
-      assert.equal(0, authLinks.length, 'Should not have an auth link')
+    it('has auth link', () => {
+      const authLink = renderedDOM().querySelector('#auth-link')
+      assert(authLink, 'Should have an auth link')
+      assert.equal('Authenticate', authLink.textContent)
+    })
+
+    it('does not display user login', () => {
+      const userLogins = renderedDOM().querySelectorAll('.user-login')
+      assert.equal(0, userLogins.length)
     })
   })
 


### PR DESCRIPTION
- Disable 'Tasks' and 'Filters' top nav buttons when the user has not provided an access token.
- Make top navigation area more compact vertically.
- Get rid of horizontal scrollbar around filter select menu.
- Disable 'Snooze', 'Archive', and 'Ignore' buttons when no visible tasks are selected.
- Disable 'Restore' button when no hidden tasks are selected.
- Use an emoji for the refresh button icon.
- Spell out 'View hidden' instead of using an eye Octicon.
- Move 'View hidden' button below filter select menu.
- Get rid of rounded corners in top navigation, as well as borders adjacent to the window edges on the top nav buttons.
- Display page titles for edit filter, new filter, and 'manage filters' views.
- Make 'Authenticate' view less noisy by removing green styling on 'you are signed in' message.

![screen shot 2016-09-24 at 4 15 16 pm](https://cloud.githubusercontent.com/assets/82317/18811343/365bf42e-8272-11e6-834b-e5a42526d161.png)

![screen shot 2016-09-24 at 4 15 28 pm](https://cloud.githubusercontent.com/assets/82317/18811342/3650df6c-8272-11e6-8ac6-2f8acff343ca.png)

![screen shot 2016-09-24 at 4 15 40 pm](https://cloud.githubusercontent.com/assets/82317/18811341/364f645c-8272-11e6-8856-00a23629e906.png)

/cc @probablycorey @summasmiff 
