### PR TITLE
Add keyboard navigation

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -59,12 +59,24 @@ class App extends React.Component {
   }
 
   setupAppMenu() {
-    const menu = new AppMenu()
-    menu.on('about-app', () => {
+    this.appMenu = new AppMenu({
+      isAuthenticated: GitHubAuth.isAuthenticated(),
+    })
+    this.appMenu.on('about-app', () => {
       this.showAbout()
     })
-    menu.on('authenticate', () => {
+    this.appMenu.on('authenticate', () => {
       this.showAuth()
+    })
+    this.appMenu.on('tasks', () => {
+      if (GitHubAuth.isAuthenticated()) {
+        this.showTaskList()
+      }
+    })
+    this.appMenu.on('filters', () => {
+      if (GitHubAuth.isAuthenticated()) {
+        this.manageFilters()
+      }
     })
   }
 
@@ -216,6 +228,7 @@ class App extends React.Component {
     if (user) {
       this.showTaskList()
     }
+    this.appMenu.setIsAuthenticated(typeof user === 'object')
   }
 
   render() {

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #FFF;
+  background-color: #fFF;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #Fff;
+  background-color: #FFF;
   min-height: 100vh;
 }
 

--- a/src/components/EditFilter/EditFilter.jsx
+++ b/src/components/EditFilter/EditFilter.jsx
@@ -71,6 +71,7 @@ class EditFilter extends React.Component {
                 value={this.state.key}
                 onChange={e => this.keyChanged(e)}
                 placeholder="e.g., Team mentions"
+                autoFocus="autofocus"
               />
             </p>
             <label className="label">Search query:</label>

--- a/src/components/FilterList/FilterList.jsx
+++ b/src/components/FilterList/FilterList.jsx
@@ -27,6 +27,10 @@ class FilterList extends React.Component {
       this.focusNextFilter()
     } else if (event.key === 'Escape') {
       this.setState({ selectedIndex: null })
+    } else if (event.key === 'Enter') {
+      if (typeof this.state.selectedIndex === 'number') {
+        this.editFocusedFilter()
+      }
     }
   }
 
@@ -34,6 +38,11 @@ class FilterList extends React.Component {
     if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
       event.preventDefault()
     }
+  }
+
+  editFocusedFilter() {
+    const key = this.props.filters[this.state.selectedIndex]
+    this.props.edit(key)
   }
 
   focusPreviousFilter() {

--- a/src/components/FilterList/FilterList.jsx
+++ b/src/components/FilterList/FilterList.jsx
@@ -27,9 +27,11 @@ class FilterList extends React.Component {
       this.focusNextFilter()
     } else if (event.key === 'Escape') {
       this.setState({ selectedIndex: null })
-    } else if (event.key === 'Enter') {
-      if (typeof this.state.selectedIndex === 'number') {
+    } else if (typeof this.state.selectedIndex === 'number') {
+      if (event.key === 'Enter') {
         this.editFocusedFilter()
+      } else if (event.key === 'Backspace') {
+        this.deleteFocusedFilter()
       }
     }
   }
@@ -42,7 +44,14 @@ class FilterList extends React.Component {
 
   editFocusedFilter() {
     const key = this.props.filters[this.state.selectedIndex]
+    this.setState({ selectedIndex: null })
     this.props.edit(key)
+  }
+
+  deleteFocusedFilter() {
+    const key = this.props.filters[this.state.selectedIndex]
+    this.setState({ selectedIndex: null })
+    this.props.delete(key)
   }
 
   focusPreviousFilter() {

--- a/src/components/FilterList/FilterList.jsx
+++ b/src/components/FilterList/FilterList.jsx
@@ -3,6 +3,63 @@ const FilterListItem = require('../FilterListItem')
 const hookUpStickyNav = require('../hookUpStickyNav')
 
 class FilterList extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { selectedIndex: null }
+    this.onKeyUp = this.onKeyUp.bind(this)
+    this.onKeyDown = this.onKeyDown.bind(this)
+  }
+
+  componentDidMount() {
+    document.addEventListener('keyup', this.onKeyUp)
+    document.addEventListener('keydown', this.onKeyDown)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keyup', this.onKeyUp)
+    document.removeEventListener('keydown', this.onKeyDown)
+  }
+
+  onKeyUp(event) {
+    if (event.key === 'ArrowUp') {
+      this.focusPreviousFilter()
+    } else if (event.key === 'ArrowDown') {
+      this.focusNextFilter()
+    } else if (event.key === 'Escape') {
+      this.setState({ selectedIndex: null })
+    }
+  }
+
+  onKeyDown(event) {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault()
+    }
+  }
+
+  focusPreviousFilter() {
+    const oldIndex = this.state.selectedIndex
+    const lastIndex = this.props.filters.length - 1
+    let newIndex = typeof oldIndex === 'number' ? oldIndex - 1 : lastIndex
+    if (newIndex < 0) {
+      newIndex = lastIndex
+    }
+    this.focusFilterAtIndex(newIndex)
+  }
+
+  focusNextFilter() {
+    const oldIndex = this.state.selectedIndex
+    let newIndex = typeof oldIndex === 'number' ? oldIndex + 1 : 0
+    if (newIndex > this.props.filters.length - 1) {
+      newIndex = 0
+    }
+    this.focusFilterAtIndex(newIndex)
+  }
+
+  focusFilterAtIndex(index) {
+    console.info('focus filter', this.props.filters[index])
+    this.setState({ selectedIndex: index })
+  }
+
   cancel(event) {
     event.preventDefault()
     this.props.cancel()
@@ -19,12 +76,13 @@ class FilterList extends React.Component {
     }
     return (
       <ul className="filter-list">
-        {this.props.filters.map(key => (
+        {this.props.filters.map((key, index) => (
           <FilterListItem
             key={key}
             filter={key}
             delete={this.props.delete}
             edit={this.props.edit}
+            isFocused={index === this.state.selectedIndex}
           />
         ))}
       </ul>

--- a/src/components/FilterListItem/FilterListItem.jsx
+++ b/src/components/FilterListItem/FilterListItem.jsx
@@ -1,12 +1,46 @@
 const React = require('react')
+const ReactDOM = require('react-dom')
 
 const Filter = require('../../models/Filter')
 
 class FilterListItem extends React.Component {
+  componentDidMount() {
+    this.ensureVisible()
+  }
+
+  componentDidUpdate() {
+    this.ensureVisible()
+  }
+
+  listItemClass() {
+    const classes = ['filter-list-item']
+    if (this.props.isFocused) {
+      classes.push('focused')
+    }
+    return classes.join(' ')
+  }
+
+  ensureVisible() {
+    if (!this.props.isFocused) {
+      return
+    }
+    const el = ReactDOM.findDOMNode(this)
+    const rect = el.getBoundingClientRect()
+    const isInView = rect.top >= 0 && rect.left >= 0 &&
+        rect.bottom <= window.innerHeight && rect.right <= window.innerWidth
+    const nav = document.querySelector('.secondary-nav')
+    const navRect = nav.getBoundingClientRect()
+    const isFullyInView = isInView && rect.top >= navRect.bottom
+    if (isFullyInView) {
+      return
+    }
+    window.scrollTo(0, el.offsetTop - navRect.bottom)
+  }
+
   render() {
     const filter = new Filter(this.props.filter)
     return (
-      <li className="filter-list-item">
+      <li className={this.listItemClass()}>
         <div className="columns">
           <div className="column filter-key is-3">
             {filter.key}
@@ -42,6 +76,7 @@ FilterListItem.propTypes = {
   filter: React.PropTypes.string.isRequired,
   delete: React.PropTypes.func.isRequired,
   edit: React.PropTypes.func.isRequired,
+  isFocused: React.PropTypes.bool.isRequired,
 }
 
 module.exports = FilterListItem

--- a/src/components/FilterListItem/FilterListItem.less
+++ b/src/components/FilterListItem/FilterListItem.less
@@ -14,4 +14,9 @@
   &:nth-child(even) {
     background-color: #f9f9f9;
   }
+
+  &.focused, &:nth-child(even).focused {
+    background-color: #ffdd57;
+    color: rgba(0, 0, 0, 0.7);
+  }
 }

--- a/src/components/HiddenTaskList/HiddenTaskList.jsx
+++ b/src/components/HiddenTaskList/HiddenTaskList.jsx
@@ -16,8 +16,8 @@ class HiddenTaskList extends React.Component {
     this.props.cancel()
   }
 
-  emptyListMessage(tasks) {
-    if (tasks.length > 0) {
+  emptyListMessage() {
+    if (this.props.tasks.length > 0) {
       return
     }
     return (
@@ -30,9 +30,7 @@ class HiddenTaskList extends React.Component {
 
   render() {
     const { activeFilter } = this.props
-    const hiddenTasks = this.props.tasks.
-        filter(task => TaskVisibility.isHiddenTask(task))
-    const isRestoreDisabled = hiddenTasks.
+    const isRestoreDisabled = this.props.tasks.
         filter(task => task.isSelected).length < 1
     return (
       <div>
@@ -42,7 +40,7 @@ class HiddenTaskList extends React.Component {
               Hidden Tasks in &ldquo;{activeFilter}&rdquo;
             </h2>
           </div>
-          {hiddenTasks.length < 1 ? '' : (
+          {this.props.tasks.length < 1 ? '' : (
             <div className="nav-right">
               <span className="nav-item">
                 <button
@@ -58,9 +56,9 @@ class HiddenTaskList extends React.Component {
           )}
         </nav>
         <div className="view-container">
-          {this.emptyListMessage(hiddenTasks)}
+          {this.emptyListMessage()}
           <ol className="task-list">
-            {hiddenTasks.map(task =>
+            {this.props.tasks.map(task =>
               <HiddenTaskListItem {...task} key={task.storageKey} />
             )}
           </ol>
@@ -77,8 +75,9 @@ HiddenTaskList.propTypes = {
   activeFilter: React.PropTypes.string.isRequired,
 }
 
-const mapStateToProps = state => ({ tasks: state.tasks })
-
 const stickyNavd = hookUpStickyNav(HiddenTaskList,
                                    '#hidden-task-list-navigation')
+const mapStateToProps = state => ({
+  tasks: state.tasks.filter(task => TaskVisibility.isHiddenTask(task)),
+})
 module.exports = connect(mapStateToProps)(stickyNavd)

--- a/src/components/NewFilter/NewFilter.jsx
+++ b/src/components/NewFilter/NewFilter.jsx
@@ -60,6 +60,7 @@ class NewFilter extends React.Component {
                 type="text"
                 name="filterKey"
                 className="input"
+                autoFocus="autofocus"
                 placeholder="e.g., Team mentions"
               />
             </p>

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -79,17 +79,8 @@ class TaskList extends React.Component {
     this.props.changeFilter(filter)
   }
 
-  visibleTasks() {
-    if (this.cachedVisibleTasks) {
-      return this.cachedVisibleTasks
-    }
-    this.cachedVisibleTasks = this.props.tasks.
-        filter(task => TaskVisibility.isVisibleTask(task))
-    return this.cachedVisibleTasks
-  }
-
   selectFocusedTask() {
-    const task = this.visibleTasks()[this.state.selectedIndex]
+    const task = this.props.tasks[this.state.selectedIndex]
     const type = task.isSelected ? 'TASKS_DESELECT' : 'TASKS_SELECT'
     this.props.dispatch({ type, task: { storageKey: task.storageKey } })
   }
@@ -97,28 +88,28 @@ class TaskList extends React.Component {
   focusNextTask() {
     const oldIndex = this.state.selectedIndex
     let newIndex = typeof oldIndex === 'number' ? oldIndex + 1 : 0
-    if (newIndex > this.visibleTasks().length - 1) {
+    if (newIndex > this.props.tasks.length - 1) {
       newIndex = 0
     }
-    console.info('focus', this.visibleTasks()[newIndex].storageKey)
+    console.info('focus', this.props.tasks[newIndex].storageKey)
     this.setState({ selectedIndex: newIndex })
   }
 
   focusPreviousTask() {
     const oldIndex = this.state.selectedIndex
-    const lastIndex = this.visibleTasks().length - 1
+    const lastIndex = this.props.tasks.length - 1
     let newIndex = typeof oldIndex === 'number' ? oldIndex - 1 : lastIndex
     if (newIndex < 0) {
       newIndex = lastIndex
     }
-    console.info('focus', this.visibleTasks()[newIndex].storageKey)
+    console.info('focus', this.props.tasks[newIndex].storageKey)
     this.setState({ selectedIndex: newIndex })
   }
 
   render() {
     const filters = Filters.findAll()
     const lastFilterKey = LastFilter.retrieve()
-    const isSnoozeDisabled = this.visibleTasks().
+    const isSnoozeDisabled = this.props.tasks.
         filter(task => task.isSelected).length < 1
     const isArchiveDisabled = isSnoozeDisabled
     const isIgnoreDisabled = isSnoozeDisabled
@@ -198,7 +189,7 @@ class TaskList extends React.Component {
         </nav>
         <div className="task-list-container">
           <ol className="task-list">
-            {this.visibleTasks().map((task, index) => {
+            {this.props.tasks.map((task, index) => {
               const isFocused = index === this.state.selectedIndex
               const key = `${task.storageKey}-${task.isSelected}-${isFocused}`
               return <TaskListItem {...task} key={key} isFocused={isFocused} />
@@ -209,8 +200,6 @@ class TaskList extends React.Component {
     )
   }
 }
-
-const mapStateToProps = state => ({ tasks: state.tasks })
 
 TaskList.propTypes = {
   tasks: React.PropTypes.array.isRequired,
@@ -225,4 +214,7 @@ TaskList.propTypes = {
 }
 
 const stickyNavd = hookUpStickyNav(TaskList, '.task-list-navigation')
+const mapStateToProps = state => ({
+  tasks: state.tasks.filter(task => TaskVisibility.isVisibleTask(task)),
+})
 module.exports = connect(mapStateToProps)(stickyNavd)

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -12,10 +12,12 @@ class TaskList extends React.Component {
     super(props)
     this.state = { selectedIndex: null }
     this.onKeyUp = this.onKeyUp.bind(this)
+    this.onKeyDown = this.onKeyDown.bind(this)
   }
 
   componentDidMount() {
     document.addEventListener('keyup', this.onKeyUp)
+    document.addEventListener('keydown', this.onKeyDown)
   }
 
   componentDidUpdate() {
@@ -24,6 +26,7 @@ class TaskList extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener('keyup', this.onKeyUp)
+    document.removeEventListener('keydown', this.onKeyDown)
   }
 
   onSnoozeClick(event) {
@@ -46,6 +49,15 @@ class TaskList extends React.Component {
       this.focusPreviousTask()
     } else if (event.key === 'ArrowDown') {
       this.focusNextTask()
+    }
+  }
+
+  onKeyDown(event) {
+    if (event.key === ' ' && typeof this.state.selectedIndex === 'number') {
+      event.preventDefault()
+      this.selectFocusedTask()
+    } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+      event.preventDefault()
     }
   }
 
@@ -76,12 +88,19 @@ class TaskList extends React.Component {
     return this.cachedVisibleTasks
   }
 
+  selectFocusedTask() {
+    const task = this.visibleTasks()[this.state.selectedIndex]
+    const type = task.isSelected ? 'TASKS_DESELECT' : 'TASKS_SELECT'
+    this.props.dispatch({ type, task: { storageKey: task.storageKey } })
+  }
+
   focusNextTask() {
     const oldIndex = this.state.selectedIndex
     let newIndex = typeof oldIndex === 'number' ? oldIndex + 1 : 0
     if (newIndex > this.visibleTasks().length - 1) {
       newIndex = 0
     }
+    console.info('focus', this.visibleTasks()[newIndex].storageKey)
     this.setState({ selectedIndex: newIndex })
   }
 
@@ -92,6 +111,7 @@ class TaskList extends React.Component {
     if (newIndex < 0) {
       newIndex = lastIndex
     }
+    console.info('focus', this.visibleTasks()[newIndex].storageKey)
     this.setState({ selectedIndex: newIndex })
   }
 
@@ -206,4 +226,5 @@ TaskList.propTypes = {
   editFilter: React.PropTypes.func.isRequired,
 }
 
-module.exports = connect(mapStateToProps)(hookUpStickyNav(TaskList, '.task-list-navigation'))
+const stickyNavd = hookUpStickyNav(TaskList, '.task-list-navigation')
+module.exports = connect(mapStateToProps)(stickyNavd)

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -52,6 +52,8 @@ class TaskList extends React.Component {
       this.focusPreviousTask()
     } else if (event.key === 'ArrowDown') {
       this.focusNextTask()
+    } else if (event.key === 'Escape') {
+      this.setState({ selectedIndex: null })
     }
   }
 

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -20,10 +20,6 @@ class TaskList extends React.Component {
     document.addEventListener('keydown', this.onKeyDown)
   }
 
-  componentDidUpdate() {
-    this.cachedVisibleTasks = null
-  }
-
   componentWillUnmount() {
     document.removeEventListener('keyup', this.onKeyUp)
     document.removeEventListener('keydown', this.onKeyDown)
@@ -118,7 +114,7 @@ class TaskList extends React.Component {
   }
 
   focusTaskAtIndex(index) {
-    console.info('focus', this.props.tasks[index].storageKey)
+    console.info('focus task', this.props.tasks[index].storageKey)
     this.setState({ selectedIndex: index })
   }
 

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -44,11 +44,6 @@ class TaskList extends React.Component {
     this.props.dispatch({ type: 'TASKS_IGNORE' })
   }
 
-  isFiltersMenuFocused() {
-    return document.activeElement &&
-        document.activeElement.id === 'filters-menu'
-  }
-
   onKeyUp(event) {
     if (this.isFiltersMenuFocused()) {
       return
@@ -70,6 +65,11 @@ class TaskList extends React.Component {
     } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
       event.preventDefault()
     }
+  }
+
+  isFiltersMenuFocused() {
+    return document.activeElement &&
+        document.activeElement.id === 'filters-menu'
   }
 
   changeFilter(event) {

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -104,8 +104,7 @@ class TaskList extends React.Component {
     if (newIndex > this.props.tasks.length - 1) {
       newIndex = 0
     }
-    console.info('focus', this.props.tasks[newIndex].storageKey)
-    this.setState({ selectedIndex: newIndex })
+    this.focusTaskAtIndex(newIndex)
   }
 
   focusPreviousTask() {
@@ -115,8 +114,12 @@ class TaskList extends React.Component {
     if (newIndex < 0) {
       newIndex = lastIndex
     }
-    console.info('focus', this.props.tasks[newIndex].storageKey)
-    this.setState({ selectedIndex: newIndex })
+    this.focusTaskAtIndex(newIndex)
+  }
+
+  focusTaskAtIndex(index) {
+    console.info('focus', this.props.tasks[index].storageKey)
+    this.setState({ selectedIndex: index })
   }
 
   render() {

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -44,7 +44,15 @@ class TaskList extends React.Component {
     this.props.dispatch({ type: 'TASKS_IGNORE' })
   }
 
+  isFiltersMenuFocused() {
+    return document.activeElement &&
+        document.activeElement.id === 'filters-menu'
+  }
+
   onKeyUp(event) {
+    if (this.isFiltersMenuFocused()) {
+      return
+    }
     if (event.key === 'ArrowUp') {
       this.focusPreviousTask()
     } else if (event.key === 'ArrowDown') {
@@ -53,6 +61,9 @@ class TaskList extends React.Component {
   }
 
   onKeyDown(event) {
+    if (this.isFiltersMenuFocused()) {
+      return
+    }
     if (event.key === ' ' && typeof this.state.selectedIndex === 'number') {
       event.preventDefault()
       this.selectFocusedTask()

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -198,13 +198,11 @@ class TaskList extends React.Component {
         </nav>
         <div className="task-list-container">
           <ol className="task-list">
-            {this.visibleTasks().map((task, index) =>
-              <TaskListItem
-                {...task}
-                key={task.storageKey}
-                isFocused={index === this.state.selectedIndex}
-              />
-            )}
+            {this.visibleTasks().map((task, index) => {
+              const isFocused = index === this.state.selectedIndex
+              const key = `${task.storageKey}-${task.isSelected}-${isFocused}`
+              return <TaskListItem {...task} key={key} isFocused={isFocused} />
+            })}
           </ol>
         </div>
       </div>

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -1,5 +1,6 @@
 const React = require('react')
 const { connect } = require('react-redux')
+const { shell } = require('electron')
 
 const TaskListItem = require('../TaskListItem')
 const hookUpStickyNav = require('../hookUpStickyNav')
@@ -50,6 +51,10 @@ class TaskList extends React.Component {
       this.focusNextTask()
     } else if (event.key === 'Escape') {
       this.setState({ selectedIndex: null })
+    } else if (event.key === 'Enter') {
+      if (typeof this.state.selectedIndex === 'number') {
+        this.openLinkToFocusedTask()
+      }
     }
   }
 
@@ -92,6 +97,11 @@ class TaskList extends React.Component {
     const task = this.props.tasks[this.state.selectedIndex]
     const type = task.isSelected ? 'TASKS_DESELECT' : 'TASKS_SELECT'
     this.props.dispatch({ type, task: { storageKey: task.storageKey } })
+  }
+
+  openLinkToFocusedTask() {
+    const task = this.props.tasks[this.state.selectedIndex]
+    shell.openExternal(task.url)
   }
 
   focusNextTask() {

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -12,9 +12,9 @@ class TaskListItem extends React.Component {
     this.ensureVisible()
   }
 
-  onChange(event) {
-    const { storageKey } = this.props
-    const type = event.target.checked ? 'TASKS_SELECT' : 'TASKS_DESELECT'
+  onToggleCheckbox() {
+    const { storageKey, isSelected } = this.props
+    const type = isSelected ? 'TASKS_DESELECT' : 'TASKS_SELECT'
 
     this.props.dispatch({ type, task: { storageKey } })
   }
@@ -73,7 +73,8 @@ class TaskListItem extends React.Component {
 
   render() {
     const { updatedAt, repository, title, repositoryOwner, user, storageKey,
-            url, state, repositoryOwnerAvatar, userAvatar } = this.props
+            url, state, repositoryOwnerAvatar, userAvatar,
+            isSelected } = this.props
 
     return (
       <li className={this.listItemClass()}>
@@ -82,7 +83,8 @@ class TaskListItem extends React.Component {
             id={storageKey}
             type="checkbox"
             className="task-list-item-checkbox"
-            onChange={event => this.onChange(event)}
+            checked={!!isSelected}
+            onChange={event => this.onToggleCheckbox(event)}
           />
         </div>
         <div className="column has-text-centered">

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -83,8 +83,8 @@ class TaskListItem extends React.Component {
             id={storageKey}
             type="checkbox"
             className="task-list-item-checkbox"
-            checked={!!isSelected}
-            onChange={event => this.onToggleCheckbox(event)}
+            defaultChecked={!!isSelected}
+            onChange={() => this.onToggleCheckbox()}
           />
         </div>
         <div className="column has-text-centered">

--- a/src/components/TaskListItem/TaskListItem.less
+++ b/src/components/TaskListItem/TaskListItem.less
@@ -8,6 +8,18 @@
   .checkbox {
     display: block;
   }
+
+  &.focused, &:nth-child(even).focused {
+    background-color: #ffdd57;
+
+    &, .task-list-meta, .task-list-item-time, a:hover, a:focus, a:active {
+      color: rgba(0, 0, 0, 0.7);
+    }
+
+    a, a:link, a:visited {
+      color: #3273dc;
+    }
+  }
 }
 
 input.task-list-item-checkbox[type="checkbox"] {

--- a/src/models/AppMenu.js
+++ b/src/models/AppMenu.js
@@ -8,8 +8,9 @@ const packagePath = path.join(__dirname, '..', '..', 'package.json')
 const packageInfo = require(packagePath)
 
 class AppMenu extends EventEmitter {
-  constructor() {
+  constructor(options) {
     super()
+    this.options = options
     this.template = []
     const self = this
     this.aboutOption = {
@@ -25,7 +26,8 @@ class AppMenu extends EventEmitter {
       click() { self.emit('authenticate') },
     }
     this.buildMenu()
-    Menu.setApplicationMenu(Menu.buildFromTemplate(this.template))
+    this.menu = Menu.buildFromTemplate(this.template)
+    Menu.setApplicationMenu(this.menu)
   }
 
   buildMenu() {
@@ -54,7 +56,42 @@ class AppMenu extends EventEmitter {
       ],
     }
   }
-  getToolMenu() {
+
+  setIsAuthenticated(isAuthenticated) {
+    this.options = this.options || {}
+    this.options.isAuthenticated = isAuthenticated
+    const viewMenu = this.menu.items[2].submenu
+    viewMenu.items[0].enabled = isAuthenticated // Tasks
+    viewMenu.items[1].enabled = isAuthenticated // Filters
+  }
+
+  getViewMenu() {
+    const self = this
+    return {
+      label: 'View',
+      submenu: [
+        {
+          label: 'Tasks',
+          accelerator: 'CmdOrCtrl+1',
+          click() { self.emit('tasks') },
+          enabled: this.options.isAuthenticated,
+        },
+        {
+          label: 'Filters',
+          accelerator: 'CmdOrCtrl+2',
+          click() { self.emit('filters') },
+          enabled: this.options.isAuthenticated,
+        },
+        {
+          label: 'Authentication',
+          accelerator: 'CmdOrCtrl+3',
+          click() { self.emit('authenticate') },
+        },
+      ],
+    }
+  }
+
+  getToolsMenu() {
     return {
       label: 'Tools',
       submenu: [
@@ -71,8 +108,8 @@ class AppMenu extends EventEmitter {
     }
   }
 
-  buildOSXMenu() {
-    this.template.push({
+  getAppMenu() {
+    return {
       label: app.getName(),
       submenu: [
         this.aboutOption,
@@ -85,9 +122,14 @@ class AppMenu extends EventEmitter {
           click() { app.quit() },
         },
       ],
-    })
+    }
+  }
+
+  buildOSXMenu() {
+    this.template.push(this.getAppMenu())
     this.template.push(this.getEditMenu())
-    this.template.push(this.getToolMenu())
+    this.template.push(this.getViewMenu())
+    this.template.push(this.getToolsMenu())
     this.template.push({
       label: 'Help',
       role: 'help',
@@ -97,8 +139,8 @@ class AppMenu extends EventEmitter {
     })
   }
 
-  buildNonOSXMenu() {
-    this.template.push({
+  getFileMenu() {
+    return {
       label: 'File',
       submenu: [
         this.authOption,
@@ -108,9 +150,14 @@ class AppMenu extends EventEmitter {
           click() { app.quit() },
         },
       ],
-    })
+    }
+  }
+
+  buildNonOSXMenu() {
+    this.template.push(this.getFileMenu())
     this.template.push(this.getEditMenu())
-    this.template.push(this.getToolMenu())
+    this.template.push(this.getViewMenu())
+    this.template.push(this.getToolsMenu())
     this.template.push({
       label: 'Help',
       submenu: [

--- a/src/models/AppMenu.js
+++ b/src/models/AppMenu.js
@@ -61,15 +61,14 @@ class AppMenu extends EventEmitter {
         {
           label: 'Developer Tools',
           accelerator: 'CmdOrCtrl+Shift+I',
-          click (item, win) {
+          click(item, win) {
             if (win) {
-              win.webContents.toggleDevTools();
+              win.webContents.toggleDevTools()
             }
-          }
-        }
-      ]
+          },
+        },
+      ],
     }
-
   }
 
   buildOSXMenu() {


### PR DESCRIPTION
Fixes #39 by adding the following keyboard controls:
- While in the tasks list, up/down arrows highlight tasks. Hitting space while a task is highlighted will toggle its selection. Hitting escape will clear the highlight. Hitting enter while a task is highlighted will open it in the browser.
- While in the filters list, up/down arrows highlight filters. Hitting enter while a filter is highlighted will take you to the edit view. Hitting backspace while a filter is highlighted will delete the filter. Hitting escape will clear the highlight.

Other changes:
- The filter name field is now autofocused on both the Edit Filter and New Filter views.
- This adds a new View menu with shortcuts to switch between Tasks, Filters, and the authentication view. In macOS, Cmd-1 takes you to Tasks, Cmd-2 to Filters, and Cmd-3 to authentication. Tasks and Filters options are disabled when the user has not provided an access token.

This is just a first step for keyboard navigation. #50 can build upon this by adding key combinations to archive/snooze/ignore selected tasks.

/cc @probablycorey @summasmiff 
