### PR TITLE
Paginate task list

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -99,6 +99,7 @@ class App extends React.Component {
     const save = key => this.savedFilter(key)
     const manageFilters = () => this.manageFilters()
     const loadFilter = key => this.loadFilter(key)
+    const loadNextPage = this.state.nextUrl ? () => this.loadNextPage() : null
     switch (this.state.view) {
       case 'tasks': return (
         <TaskList
@@ -109,6 +110,7 @@ class App extends React.Component {
           showAuth={() => this.showAuth()}
           showHidden={() => this.showHidden()}
           editFilter={editFilter}
+          loadNextPage={loadNextPage}
         />)
       case 'filters': return (
         <FilterList
@@ -147,6 +149,24 @@ class App extends React.Component {
         />
       )
     }
+  }
+
+  loadNextPage() {
+    if (!this.state.nextUrl) {
+      return
+    }
+    const github = new GitHub()
+    const prevUrl = this.state.nextUrl
+    github.getTasksFromUrl(prevUrl).then(result => {
+      const { tasks, nextUrl } = result
+      this.setState({ nextUrl, prevUrl })
+      this.props.dispatch({ type: 'TASKS_UPDATE', tasks,
+                            notifications: this.state.notifications })
+      window.scrollTo(0, 0)
+    }).catch(err => {
+      console.error('failed to get next page of tasks from GitHub',
+                    this.nextUrl, err)
+    })
   }
 
   showAbout() {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -43,7 +43,8 @@ class App extends React.Component {
 
   onNotificationsFetched(notifications, query) {
     const github = new GitHub()
-    github.getTasks(query).then(tasks => {
+    github.getTasks(query).then(result => {
+      const { tasks } = result
       this.props.dispatch({ type: 'TASKS_UPDATE', tasks, notifications })
     }).catch(err => {
       console.error('failed to get tasks from GitHub', err)

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -198,7 +198,7 @@ class App extends React.Component {
     github.getTasksFromUrl(url).then(result => {
       const { tasks } = result
       const urls = this.state.urls.slice(0, this.state.urls.length - 1)
-      this.setState({ urls, currentUrlIndex: urls.indexOf(url) - 1 })
+      this.setState({ urls, currentUrlIndex: this.state.currentUrlIndex - 1 })
       this.props.dispatch({ type: 'TASKS_UPDATE', tasks,
                             notifications: this.state.notifications })
       window.scrollTo(0, 0)

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -166,7 +166,7 @@ class App extends React.Component {
   }
 
   loadNextPage() {
-    if (!this.state.urls) {
+    if (!this.state.urls || this.state.urls.length < 1) {
       return
     }
     this.props.dispatch({ type: 'TASKS_EMPTY' })
@@ -186,7 +186,7 @@ class App extends React.Component {
   }
 
   loadPrevPage() {
-    if (!this.state.urls) {
+    if (!this.state.urls || this.state.urls.length < 1) {
       return
     }
     this.props.dispatch({ type: 'TASKS_EMPTY' })

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -60,8 +60,11 @@ class App extends React.Component {
     const github = new GitHub()
     github.getTasks(query).then(result => {
       const { tasks, nextUrl, currentUrl } = result
-      this.setState({ urls: [currentUrl, nextUrl], currentUrlIndex: 0,
-                      loadingTasks: false })
+      const urls = [currentUrl]
+      if (nextUrl) {
+        urls.push(nextUrl)
+      }
+      this.setState({ urls, currentUrlIndex: 0, loadingTasks: false })
       this.props.dispatch({ type: 'TASKS_UPDATE', tasks,
                             notifications: this.state.notifications })
     }).catch(err => {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -262,7 +262,7 @@ class App extends React.Component {
     this.props.dispatch({ type: 'TASKS_EMPTY' })
     LastFilter.save(key)
     const filter = new Filter(key)
-    this.setState({ filter: key, nextUrl: null })
+    this.setState({ filter: key, urls: null, currentUrlIndex: null })
     const query = filter.retrieve()
     this.loadTasks(query)
   }

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -42,12 +42,6 @@ class App extends React.Component {
     }
   }
 
-  onNotificationsFetched(notifications, query) {
-    this.setState({ notifications }, () => {
-      this.getTasksAfterNotifications(query)
-    })
-  }
-
   onUserLoad(user) {
     if (user) {
       const filters = new DefaultFilters(user.login)
@@ -232,7 +226,9 @@ class App extends React.Component {
       return
     }
     github.getNotifications().then(notifications => {
-      this.onNotificationsFetched(notifications, query)
+      this.setState({ notifications }, () => {
+        this.getTasksAfterNotifications(query)
+      })
     }).catch(err => {
       console.error('failed to get notifications from GitHub', err)
       this.setState({ loadingTasks: false })

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -170,6 +170,7 @@ class App extends React.Component {
     if (!this.state.urls || this.state.urls.length < 1) {
       return
     }
+    this.setState({ loadingTasks: true })
     this.props.dispatch({ type: 'TASKS_EMPTY' })
     const github = new GitHub()
     const url = this.state.urls[this.state.urls.length - 1]
@@ -179,13 +180,15 @@ class App extends React.Component {
       if (nextUrl) {
         urls = urls.concat([nextUrl])
       }
-      this.setState({ urls, currentUrlIndex: urls.indexOf(url) })
+      this.setState({ urls, currentUrlIndex: urls.indexOf(url),
+                      loadingTasks: false })
       this.props.dispatch({ type: 'TASKS_UPDATE', tasks,
                             notifications: this.state.notifications })
       window.scrollTo(0, 0)
     }).catch(err => {
       console.error('failed to get next page of tasks from GitHub',
                     this.state.urls, err)
+      this.setState({ loadingTasks: false })
     })
   }
 
@@ -193,19 +196,22 @@ class App extends React.Component {
     if (!this.state.urls || this.state.urls.length < 1) {
       return
     }
+    this.setState({ loadingTasks: true })
     this.props.dispatch({ type: 'TASKS_EMPTY' })
     const github = new GitHub()
     const url = this.state.urls[this.state.urls.length - 2]
     github.getTasksFromUrl(url).then(result => {
       const { tasks } = result
       const urls = this.state.urls.slice(0, this.state.urls.length - 1)
-      this.setState({ urls, currentUrlIndex: this.state.currentUrlIndex - 1 })
+      this.setState({ urls, currentUrlIndex: this.state.currentUrlIndex - 1,
+                      loadingTasks: false })
       this.props.dispatch({ type: 'TASKS_UPDATE', tasks,
                             notifications: this.state.notifications })
       window.scrollTo(0, 0)
     }).catch(err => {
       console.error('failed to get previous page of tasks from GitHub',
                     this.state.urls, err)
+      this.setState({ loadingTasks: false })
     })
   }
 

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -169,6 +169,7 @@ class App extends React.Component {
     if (!this.state.urls) {
       return
     }
+    this.props.dispatch({ type: 'TASKS_EMPTY' })
     const github = new GitHub()
     const url = this.state.urls[this.state.urls.length - 1]
     github.getTasksFromUrl(url).then(result => {
@@ -188,6 +189,7 @@ class App extends React.Component {
     if (!this.state.urls) {
       return
     }
+    this.props.dispatch({ type: 'TASKS_EMPTY' })
     const github = new GitHub()
     const url = this.state.urls[this.state.urls.length - 2]
     github.getTasksFromUrl(url).then(result => {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -174,7 +174,10 @@ class App extends React.Component {
     const url = this.state.urls[this.state.urls.length - 1]
     github.getTasksFromUrl(url).then(result => {
       const { tasks, nextUrl } = result
-      const urls = this.state.urls.concat([nextUrl])
+      let urls = this.state.urls
+      if (nextUrl) {
+        urls = urls.concat([nextUrl])
+      }
       this.setState({ urls, currentUrlIndex: urls.indexOf(url) })
       this.props.dispatch({ type: 'TASKS_UPDATE', tasks,
                             notifications: this.state.notifications })

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #fFF;
+  background-color: #Fff;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #ffffff;
+  background-color: #FFFfff;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -56,7 +56,7 @@ body {
   }
 }
 
-.tertiary-nav {
+.tertiary-nav.nav {
   min-height: 0;
   border-bottom: 1px solid rgba(211, 214, 219, 0.5);
   margin-bottom: 15px;
@@ -68,6 +68,14 @@ body {
   .compact-vertically .is-small {
     line-height: 14px;
     height: 22px;
+  }
+
+  span.button.is-link {
+    cursor: default;
+
+    &:hover, &:focus {
+      text-decoration: none;
+    }
   }
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -90,3 +90,14 @@ body {
 .lh {
   line-height: 32px;
 }
+
+.pagination > .button:not(:first-child) {
+  -webkit-box-ordinal-group: 2;
+  order: 1;
+}
+
+.pagination .button {
+  display: block;
+  min-width: 32px;
+  padding: 3px 8px;
+}

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -219,13 +219,17 @@ class TaskList extends React.Component {
                 className="is-link is-small button"
                 title="Edit selected filter"
               >Edit</button>
-              {typeof this.props.currentPage === 'number' ? (
+            </span>
+          </div>
+          {typeof this.props.currentPage === 'number' ? (
+            <div className="nav-right">
+              <span className="nav-item compact-vertically">
                 <span className="is-small button is-link">
                   Page {this.props.currentPage}
                 </span>
-              ) : ''}
-            </span>
-          </div>
+              </span>
+            </div>
+          ) : ''}
         </nav>
         <div className="task-list-container">
           <ol className="task-list">

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -70,6 +70,11 @@ class TaskList extends React.Component {
     }
   }
 
+  loadNextPage() {
+    event.currentTarget.blur() // defocus button
+    this.props.loadNextPage()
+  }
+
   isFiltersMenuFocused() {
     return document.activeElement &&
         document.activeElement.id === 'filters-menu'
@@ -217,6 +222,15 @@ class TaskList extends React.Component {
               return <TaskListItem {...task} key={key} isFocused={isFocused} />
             })}
           </ol>
+          {typeof this.props.loadNextPage === 'function' ? (
+            <nav className="pagination">
+              <button
+                type="button"
+                className="button"
+                onClick={() => this.loadNextPage()}
+              >Next &rarr;</button>
+            </nav>
+          ) : ''}
         </div>
       </div>
     )
@@ -233,6 +247,7 @@ TaskList.propTypes = {
   showAuth: React.PropTypes.func.isRequired,
   showHidden: React.PropTypes.func.isRequired,
   editFilter: React.PropTypes.func.isRequired,
+  loadNextPage: React.PropTypes.func,
 }
 
 const stickyNavd = hookUpStickyNav(TaskList, '.task-list-navigation')

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -162,6 +162,32 @@ class TaskList extends React.Component {
     return <p>You&rsquo;ve reached the end!</p>
   }
 
+  paginationSection() {
+    const haveNextPage = typeof this.props.loadNextPage === 'function'
+    const havePrevPage = typeof this.props.loadPrevPage === 'function'
+    const havePagination = haveNextPage || havePrevPage
+    if (!havePagination) {
+      return null
+    }
+    return (
+      <nav className="pagination">
+        <button
+          type="button"
+          className="button"
+          onClick={e => this.loadPrevPage(e)}
+          disabled={!havePrevPage}
+        >&larr; Previous Page</button>
+        <button
+          type="button"
+          className="button"
+          onClick={e => this.loadNextPage(e)}
+          disabled={!haveNextPage}
+        >Next Page &rarr;</button>
+        <ul></ul>
+      </nav>
+    )
+  }
+
   render() {
     const filters = Filters.findAll()
     const lastFilterKey = LastFilter.retrieve()
@@ -169,9 +195,6 @@ class TaskList extends React.Component {
         filter(task => task.isSelected).length < 1
     const isArchiveDisabled = isSnoozeDisabled
     const isIgnoreDisabled = isSnoozeDisabled
-    const haveNextPage = typeof this.props.loadNextPage === 'function'
-    const havePrevPage = typeof this.props.loadPrevPage === 'function'
-    const havePagination = haveNextPage || havePrevPage
     return (
       <div>
         <nav className="task-list-navigation secondary-nav nav has-tertiary-nav">
@@ -257,23 +280,7 @@ class TaskList extends React.Component {
         </nav>
         <div className="task-list-container">
           {this.taskListOrMessage()}
-          {havePagination ? (
-            <nav className="pagination">
-              <button
-                type="button"
-                className="button"
-                onClick={e => this.loadPrevPage(e)}
-                disabled={!havePrevPage}
-              >&larr; Previous Page</button>
-              <button
-                type="button"
-                className="button"
-                onClick={e => this.loadNextPage(e)}
-                disabled={!haveNextPage}
-              >Next Page &rarr;</button>
-              <ul></ul>
-            </nav>
-          ) : ''}
+          {this.paginationSection()}
         </div>
       </div>
     )

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -75,6 +75,11 @@ class TaskList extends React.Component {
     this.props.loadNextPage()
   }
 
+  loadPrevPage() {
+    event.currentTarget.blur() // defocus button
+    this.props.loadPrevPage()
+  }
+
   isFiltersMenuFocused() {
     return document.activeElement &&
         document.activeElement.id === 'filters-menu'
@@ -140,6 +145,9 @@ class TaskList extends React.Component {
         filter(task => task.isSelected).length < 1
     const isArchiveDisabled = isSnoozeDisabled
     const isIgnoreDisabled = isSnoozeDisabled
+    const haveNextPage = typeof this.props.loadNextPage === 'function'
+    const havePrevPage = typeof this.props.loadPrevPage === 'function'
+    const havePagination = haveNextPage || havePrevPage
     return (
       <div>
         <nav className="task-list-navigation secondary-nav nav has-tertiary-nav">
@@ -222,13 +230,22 @@ class TaskList extends React.Component {
               return <TaskListItem {...task} key={key} isFocused={isFocused} />
             })}
           </ol>
-          {typeof this.props.loadNextPage === 'function' ? (
+          {havePagination ? (
             <nav className="pagination">
-              <button
-                type="button"
-                className="button"
-                onClick={() => this.loadNextPage()}
-              >Next &rarr;</button>
+              {havePrevPage ? (
+                <button
+                  type="button"
+                  className="button"
+                  onClick={() => this.loadPrevPage()}
+                >&larr; Previous</button>
+              ) : ''}
+              {haveNextPage ? (
+                <button
+                  type="button"
+                  className="button"
+                  onClick={() => this.loadNextPage()}
+                >Next &rarr;</button>
+              ) : ''}
             </nav>
           ) : ''}
         </div>
@@ -247,6 +264,7 @@ TaskList.propTypes = {
   showAuth: React.PropTypes.func.isRequired,
   showHidden: React.PropTypes.func.isRequired,
   editFilter: React.PropTypes.func.isRequired,
+  loadPrevPage: React.PropTypes.func,
   loadNextPage: React.PropTypes.func,
 }
 

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -138,6 +138,30 @@ class TaskList extends React.Component {
     this.setState({ selectedIndex: index })
   }
 
+  taskListOrMessage() {
+    if (this.props.tasks.length > 0) {
+      return (
+        <ol className="task-list">
+          {this.props.tasks.map((task, index) => {
+            const isFocused = index === this.state.selectedIndex
+            const key = `${task.storageKey}-${task.isSelected}-${isFocused}`
+            return (
+              <TaskListItem
+                {...task}
+                key={key}
+                isFocused={isFocused}
+              />
+            )
+          })}
+        </ol>
+      )
+    }
+    if (this.props.loading) {
+      return <p>Loading...</p>
+    }
+    return <p>You&rsquo;ve reached the end!</p>
+  }
+
   render() {
     const filters = Filters.findAll()
     const lastFilterKey = LastFilter.retrieve()
@@ -232,29 +256,7 @@ class TaskList extends React.Component {
           ) : ''}
         </nav>
         <div className="task-list-container">
-          {this.props.tasks.length > 0 ? (
-            <ol className="task-list">
-              {this.props.tasks.map((task, index) => {
-                const isFocused = index === this.state.selectedIndex
-                const key = `${task.storageKey}-${task.isSelected}-${isFocused}`
-                return (
-                  <TaskListItem
-                    {...task}
-                    key={key}
-                    isFocused={isFocused}
-                  />
-                )
-              })}
-            </ol>
-          ) : (
-            <p>
-              {this.props.loading ? (
-                <span>Loading...</span>
-              ) : (
-                <span>You&rsquo;ve reached the end!</span>
-              )}
-            </p>
-          )}
+          {this.taskListOrMessage()}
           {havePagination ? (
             <nav className="pagination">
               <button

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -70,12 +70,12 @@ class TaskList extends React.Component {
     }
   }
 
-  loadNextPage() {
+  loadNextPage(event) {
     event.currentTarget.blur() // defocus button
     this.props.loadNextPage()
   }
 
-  loadPrevPage() {
+  loadPrevPage(event) {
     event.currentTarget.blur() // defocus button
     this.props.loadPrevPage()
   }
@@ -237,20 +237,19 @@ class TaskList extends React.Component {
           </ol>
           {havePagination ? (
             <nav className="pagination">
-              {havePrevPage ? (
-                <button
-                  type="button"
-                  className="button"
-                  onClick={() => this.loadPrevPage()}
-                >&larr; Previous Page</button>
-              ) : ''}
-              {haveNextPage ? (
-                <button
-                  type="button"
-                  className="button"
-                  onClick={() => this.loadNextPage()}
-                >Next Page &rarr;</button>
-              ) : ''}
+              <button
+                type="button"
+                className="button"
+                onClick={e => this.loadPrevPage(e)}
+                disabled={!havePrevPage}
+              >&larr; Previous Page</button>
+              <button
+                type="button"
+                className="button"
+                onClick={e => this.loadNextPage(e)}
+                disabled={!haveNextPage}
+              >Next Page &rarr;</button>
+              <ul></ul>
             </nav>
           ) : ''}
         </div>

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -219,6 +219,11 @@ class TaskList extends React.Component {
                 className="is-link is-small button"
                 title="Edit selected filter"
               >Edit</button>
+              {typeof this.props.currentPage === 'number' ? (
+                <span className="is-small button is-link">
+                  Page {this.props.currentPage}
+                </span>
+              ) : ''}
             </span>
           </div>
         </nav>
@@ -266,6 +271,7 @@ TaskList.propTypes = {
   editFilter: React.PropTypes.func.isRequired,
   loadPrevPage: React.PropTypes.func,
   loadNextPage: React.PropTypes.func,
+  currentPage: React.PropTypes.number,
 }
 
 const stickyNavd = hookUpStickyNav(TaskList, '.task-list-navigation')

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -242,14 +242,14 @@ class TaskList extends React.Component {
                   type="button"
                   className="button"
                   onClick={() => this.loadPrevPage()}
-                >&larr; Previous</button>
+                >&larr; Previous Page</button>
               ) : ''}
               {haveNextPage ? (
                 <button
                   type="button"
                   className="button"
                   onClick={() => this.loadNextPage()}
-                >Next &rarr;</button>
+                >Next Page &rarr;</button>
               ) : ''}
             </nav>
           ) : ''}

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -224,7 +224,7 @@ class TaskList extends React.Component {
           {typeof this.props.currentPage === 'number' ? (
             <div className="nav-right">
               <span className="nav-item compact-vertically">
-                <span className="is-small button is-link">
+                <span className="current-page is-small button is-link">
                   Page {this.props.currentPage}
                 </span>
               </span>

--- a/src/components/TaskList/TaskList.less
+++ b/src/components/TaskList/TaskList.less
@@ -4,6 +4,10 @@
     padding: 15px;
     border-top: 1px solid #dbdbdb;
   }
+
+  & > p {
+    padding: 0 15px 15px 15px;
+  }
 }
 
 #top-list-navigation {

--- a/src/components/TaskList/TaskList.less
+++ b/src/components/TaskList/TaskList.less
@@ -1,5 +1,9 @@
 .task-list-container {
-  padding: 0 20px 20px 20px;
+  & > .pagination {
+    justify-content: flex-start;
+    padding: 15px;
+    border-top: 1px solid #dbdbdb;
+  }
 }
 
 #top-list-navigation {
@@ -36,5 +40,7 @@
 }
 
 .task-list {
+  padding: 0 0 20px 0;
   list-style: none;
+  margin-bottom: -10px;
 }

--- a/src/components/TaskListItem/TaskListItem.less
+++ b/src/components/TaskListItem/TaskListItem.less
@@ -1,5 +1,6 @@
 .task-list-item {
   font-size: 16px;
+  padding: 0 15px;
 
   .checkbox.main-label {
     color: #333;

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -68,7 +68,8 @@ class GitHub extends Fetcher {
   getTasksFromUrl(urlPath) {
     return this.get(urlPath).then(result => {
       const { json, nextUrl } = result
-      return { tasks: json.items.map(d => getTask(d)), nextUrl }
+      return { tasks: json.items.map(d => getTask(d)), nextUrl,
+               currentUrl: urlPath }
     })
   }
 

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -61,15 +61,16 @@ class GitHub extends Fetcher {
 
   // https://developer.github.com/v3/search/#search-issues
   getTasks(query = Config.searchQuery) {
-    const urlPath = `search/issues?q=${encodeURIComponent(query)}`
-    return this.getTasksFromUrl(urlPath)
+    const params = `?per_page=30&q=${encodeURIComponent(query)}`
+    const url = `${Config.githubApiUrl}/search/issues${params}`
+    return this.getTasksFromUrl(url)
   }
 
-  getTasksFromUrl(urlPath) {
-    return this.get(urlPath).then(result => {
+  getTasksFromUrl(url) {
+    return this.get(url).then(result => {
       const { json, nextUrl } = result
       return { tasks: json.items.map(d => getTask(d)), nextUrl,
-               currentUrl: urlPath }
+               currentUrl: url }
     })
   }
 

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -94,11 +94,15 @@ class GitHub extends Fetcher {
     }
   }
 
-  get(relativeOrAbsoluteUrl, previousJson) {
-    let url = relativeOrAbsoluteUrl
-    if (url.indexOf('http') !== 0) {
-      url = `${Config.githubApiUrl}/${relativeOrAbsoluteUrl}`
+  getFullUrl(relativeOrAbsoluteUrl) {
+    if (relativeOrAbsoluteUrl.indexOf('http') !== 0) {
+      return `${Config.githubApiUrl}/${relativeOrAbsoluteUrl}`
     }
+    return relativeOrAbsoluteUrl
+  }
+
+  get(relativeOrAbsoluteUrl, previousJson) {
+    const url = this.getFullUrl(relativeOrAbsoluteUrl)
     const opts = { headers: this.getHeaders() }
     return new Promise((resolve, reject) => super.get(url, opts).then(res => {
       const { json, headers } = res

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -42,9 +42,10 @@ function getTask(data) {
 }
 
 class GitHub extends Fetcher {
-  constructor(token) {
+  constructor(token, perPage = 30) {
     super()
     this.token = token
+    this.perPage = perPage
   }
 
   // https://developer.github.com/v3/activity/notifications/#list-your-notifications
@@ -61,7 +62,7 @@ class GitHub extends Fetcher {
 
   // https://developer.github.com/v3/search/#search-issues
   getTasks(query = Config.searchQuery) {
-    const params = `?per_page=30&q=${encodeURIComponent(query)}`
+    const params = `?per_page=${this.perPage}&q=${encodeURIComponent(query)}`
     const url = `${Config.githubApiUrl}/search/issues${params}`
     return this.getTasksFromUrl(url)
   }

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -62,6 +62,10 @@ class GitHub extends Fetcher {
   // https://developer.github.com/v3/search/#search-issues
   getTasks(query = Config.searchQuery) {
     const urlPath = `search/issues?q=${encodeURIComponent(query)}`
+    return this.getTasksFromUrl(urlPath)
+  }
+
+  getTasksFromUrl(urlPath) {
     return this.get(urlPath).then(result => {
       const { json, nextUrl } = result
       return { tasks: json.items.map(d => getTask(d)), nextUrl }

--- a/test/components/AppTest.js
+++ b/test/components/AppTest.js
@@ -76,7 +76,8 @@ describe('App', () => {
         return Promise.resolve([])
       }
       fetchMock.get(`${Config.githubApiUrl}/user`, { login: 'testuser123' })
-      fetchMock.get(`${Config.githubApiUrl}/search/issues?q=cats`, [])
+      fetchMock.get(`${Config.githubApiUrl}/search/issues?per_page=30&q=cats`,
+                    [])
     })
 
     after(() => {

--- a/test/components/TaskListTest.js
+++ b/test/components/TaskListTest.js
@@ -60,6 +60,12 @@ describe('TaskList', () => {
     fetchMock.restore()
   })
 
+  it('shows current page', () => {
+    const pageEl = renderedDOM().querySelector('.current-page')
+    assert(pageEl, 'should have a page number section')
+    assert.equal('Page 1', pageEl.textContent)
+  })
+
   it('shows task that is not snoozed, archived, or ignored', () => {
     const taskListItems = renderedDOM().querySelectorAll('#pull-163031382')
     assert.equal(1, taskListItems.length)

--- a/test/components/TaskListTest.js
+++ b/test/components/TaskListTest.js
@@ -31,7 +31,7 @@ describe('TaskList', () => {
 
     // Fake responses from GitHub API
     fetchMock.get(`${Config.githubApiUrl}/user`, { login: 'testuser123' })
-    fetchMock.get(`${Config.githubApiUrl}/search/issues?q=cats`,
+    fetchMock.get(`${Config.githubApiUrl}/search/issues?per_page=30&q=cats`,
                   { items: [fixtures.pullRequest, fixtures.issue] })
     fetchMock.mock(fixtures.notification.url, {}, { method: 'PATCH' })
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -157,6 +157,7 @@ const task = {
   userUrl: 'https://github.com/jgrowl',
   userAvatar: 'https://github.com/jgrowl.png?size=16',
   userType: 'User',
+  apiUrl: 'https://api.github.com/repos/ansible/ansible/pulls/16510',
 }
 
 const notification = {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -152,10 +152,10 @@ const task = {
   repository: 'ansible/ansible',
   repositoryOwner: 'ansible',
   repositoryOwnerUrl: 'https://github.com/ansible',
-  repositoryOwnerAvatar: 'https://github.com/ansible.png?size=30',
+  repositoryOwnerAvatar: 'https://github.com/ansible.png?size=25',
   user: 'jgrowl',
   userUrl: 'https://github.com/jgrowl',
-  userAvatar: 'https://github.com/jgrowl.png?size=16',
+  userAvatar: 'https://github.com/jgrowl.png?size=20',
   userType: 'User',
   apiUrl: 'https://api.github.com/repos/ansible/ansible/pulls/16510',
 }

--- a/test/models/GitHubTest.js
+++ b/test/models/GitHubTest.js
@@ -30,9 +30,10 @@ describe('GitHub', () => {
   })
 
   describe('getTasks', () => {
+    const url = `${Config.githubApiUrl}/search/issues?per_page=2&q=cats`
+
     before(() => {
-      fetchMock.get(`${Config.githubApiUrl}/search/issues?per_page=2&q=cats`,
-                    { items: [fixtures.pullRequest] })
+      fetchMock.get(url, { items: [fixtures.pullRequest] })
     })
 
     it('returns a list of tasks', done => {
@@ -40,6 +41,8 @@ describe('GitHub', () => {
       github.getTasks('cats').then(actual => {
         assert.equal('object', typeof actual.tasks,
                      'should have list of tasks property')
+        assert.equal(null, actual.nextUrl, 'should not have a second page')
+        assert.equal(url, actual.currentUrl, 'should have URL that was fetched')
         assert.equal(1, actual.tasks.length,
                      'should have one task')
         assert.deepEqual(fixtures.task, actual.tasks[0],

--- a/test/models/GitHubTest.js
+++ b/test/models/GitHubTest.js
@@ -28,7 +28,7 @@ describe('GitHub', () => {
     })
   })
 
-  describe('getNextUrl', () => {
+  describe('getNextUrlFromLink', () => {
     it('returns next link', () => {
       const header = '<https://api.github.com/search/code?q=addClass' +
           '+user%3Amozilla&page=15>; rel="next", <https://api.github.com' +
@@ -40,7 +40,7 @@ describe('GitHub', () => {
       const expected = 'https://api.github.com/search/code?q=addClass+user%3Amozilla&page=15'
 
       const github = new GitHub()
-      const actual = github.getNextUrl(header)
+      const actual = github.getNextUrlFromLink(header)
 
       assert.equal(expected, actual)
     })

--- a/test/models/GitHubTest.js
+++ b/test/models/GitHubTest.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const GitHub = require('../../src/models/GitHub')
 const fetchMock = require('fetch-mock')
 const Config = require('../../src/config.json')
+const fixtures = require('../fixtures')
 
 describe('GitHub', () => {
   describe('getNotifications', () => {
@@ -23,6 +24,26 @@ describe('GitHub', () => {
       const github = new GitHub()
       github.getNotifications(date).then(actual => {
         assert.deepEqual(notifications, actual)
+        done()
+      })
+    })
+  })
+
+  describe('getTasks', () => {
+    before(() => {
+      fetchMock.get(`${Config.githubApiUrl}/search/issues?per_page=2&q=cats`,
+                    { items: [fixtures.pullRequest] })
+    })
+
+    it('returns a list of tasks', done => {
+      const github = new GitHub('123abc', 2)
+      github.getTasks('cats').then(actual => {
+        assert.equal('object', typeof actual.tasks,
+                     'should have list of tasks property')
+        assert.equal(1, actual.tasks.length,
+                     'should have one task')
+        assert.deepEqual(fixtures.task, actual.tasks[0],
+                         'should have the expected task')
         done()
       })
     })


### PR DESCRIPTION
Fixes #95 or at least makes it better by

1) Not fetching all pages of tasks immediately; and
2) Only fetching all pages of notifications once.

![screen shot 2016-10-15 at 1 43 28 pm](https://cloud.githubusercontent.com/assets/82317/19412497/635ba8c2-92dd-11e6-9ff2-0927dc647fde.png)

/cc @probablycorey @summasmiff 
