### PR TITLE
Show avatars together, overlapping

### DIFF
--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #ffFffF;
+  background-color: #fffFfF;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #fFF;
+  background-color: #FFFffF;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #fFFffF;
+  background-color: #ffFffF;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #fffFfF;
+  background-color: #ffffff;
   min-height: 100vh;
 }
 

--- a/src/components/App/App.less
+++ b/src/components/App/App.less
@@ -13,7 +13,7 @@
 @import "../HiddenTaskListItem/HiddenTaskListItem.less";
 
 body {
-  background-color: #FFFffF;
+  background-color: #fFFffF;
   min-height: 100vh;
 }
 

--- a/src/components/HiddenTaskListItem/HiddenTaskListItem.jsx
+++ b/src/components/HiddenTaskListItem/HiddenTaskListItem.jsx
@@ -51,16 +51,16 @@ class HiddenTaskListItem extends React.Component {
           />
         </div>
         <div className="column has-text-centered">
-          <label className="checkbox task-list-item-state-label" htmlFor={storageKey}>
+          <label className="checkbox state-label" htmlFor={storageKey}>
             <span title={state} className={this.iconClass()}></span>
           </label>
         </div>
-        <div className="column task-list-item-repository-owner-column has-text-right">
+        <div className="column repository-owner-column has-text-right">
           <label className="checkbox" htmlFor={storageKey}>
             <img
               src={repositoryOwnerAvatar}
               alt={repositoryOwner}
-              className="task-list-item-repository-owner-avatar"
+              className="repository-owner-avatar"
             />
           </label>
         </div>
@@ -73,7 +73,7 @@ class HiddenTaskListItem extends React.Component {
               <img
                 src={userAvatar}
                 alt={user}
-                className="task-list-item-user-avatar"
+                className="user-avatar"
               />
               <span> </span>
               <span className="task-list-item-user">

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -99,23 +99,19 @@ class TaskListItem extends React.Component {
               alt={repositoryOwner}
               className="task-list-item-repository-owner-avatar"
             />
+            <img
+              src={userAvatar}
+              alt={user}
+              className="task-list-item-user-avatar"
+            />
           </label>
         </div>
         <div className="is-8 column">
           <label className="checkbox main-label" htmlFor={storageKey}>
             <span className="task-list-item-title">{title}</span>
             <span className="task-list-meta">
-              <span>Created </span>
-              <span>by </span>
-              <img
-                src={userAvatar}
-                alt={user}
-                className="task-list-item-user-avatar"
-              />
-              <span> </span>
-              <span className="task-list-item-user">
-                {user}
-              </span>
+              <span>Created by </span>
+              <span className="task-list-item-user">{user}</span>
               <span> in </span>
               <span className="task-list-item-repository">
                 {repository}

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -127,9 +127,11 @@ class TaskListItem extends React.Component {
           </label>
         </div>
         <div className="column has-text-right">
-          <a href={url} onClick={event => this.openExternal(event)}>
-            <span className="octicon octicon-link-external"></span>
-          </a>
+          <a
+            href={url}
+            onClick={event => this.openExternal(event)}
+            className="open-task-list-item-link"
+          ><span className="octicon octicon-link-external"></span></a>
         </div>
       </li>
     )

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -88,21 +88,21 @@ class TaskListItem extends React.Component {
           />
         </div>
         <div className="column has-text-centered">
-          <label className="checkbox task-list-item-state-label" htmlFor={storageKey}>
+          <label className="checkbox state-label" htmlFor={storageKey}>
             <span title={state} className={this.iconClass()}></span>
           </label>
         </div>
-        <div className="column task-list-item-repository-owner-column has-text-right">
+        <div className="column repository-owner-column has-text-right">
           <label className="checkbox" htmlFor={storageKey}>
             <img
               src={repositoryOwnerAvatar}
               alt={repositoryOwner}
-              className="task-list-item-repository-owner-avatar"
+              className="repository-owner-avatar"
             />
             <img
               src={userAvatar}
               alt={user}
-              className="task-list-item-user-avatar"
+              className="user-avatar"
             />
           </label>
         </div>

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -110,7 +110,7 @@ class TaskListItem extends React.Component {
           <label className="checkbox main-label" htmlFor={storageKey}>
             <span className="task-list-item-title">{title}</span>
             <span className="task-list-meta">
-              <span>Created by </span>
+              <span>Opened by </span>
               <span className="task-list-item-user">{user}</span>
               <span> in </span>
               <span className="task-list-item-repository">

--- a/src/components/TaskListItem/TaskListItem.less
+++ b/src/components/TaskListItem/TaskListItem.less
@@ -48,7 +48,7 @@ input.task-list-item-checkbox[type="checkbox"] {
   line-height: 36px;
 }
 
-.task-list-item-state-label {
+.state-label {
   .octicon {
     vertical-align: top;
     font-size: 17px;
@@ -84,26 +84,26 @@ input.task-list-item-checkbox[type="checkbox"] {
   font-weight: 500;
 }
 
-.task-list-item-repository-owner-column {
+.repository-owner-column {
   flex: none;
   width: 7.33333%;
 }
 
-.task-list-item-user-avatar,
-.task-list-item-repository-owner-avatar {
+.user-avatar,
+.repository-owner-avatar {
   display: inline-block;
   vertical-align: top;
   border-radius: 5px;
 }
 
-.task-list-item-repository-owner-avatar {
+.repository-owner-avatar {
   width: 25px;
   position: absolute;
   left: 0;
   top: 0;
 }
 
-.task-list-item-user-avatar {
+.user-avatar {
   width: 20px;
   position: absolute;
   right: 0;

--- a/src/components/TaskListItem/TaskListItem.less
+++ b/src/components/TaskListItem/TaskListItem.less
@@ -1,11 +1,6 @@
 .task-list-item {
   font-size: 16px;
 
-  .octicon-link-external {
-    margin-top: 2px;
-    display: block;
-  }
-
   .checkbox.main-label {
     color: #333;
   }
@@ -42,9 +37,15 @@ input.task-list-item-checkbox[type="checkbox"] {
   width: 11.66667%;
 }
 
+.open-task-list-item-link {
+  display: inline-block;
+  line-height: 33px;
+}
+
 .task-list-item-time {
   color: #777;
   font-size: 12px;
+  line-height: 36px;
 }
 
 .task-list-item-state-label {

--- a/src/components/TaskListItem/TaskListItem.less
+++ b/src/components/TaskListItem/TaskListItem.less
@@ -85,13 +85,19 @@ input.task-list-item-checkbox[type="checkbox"] {
 .task-list-item-repository-owner-avatar {
   display: inline-block;
   vertical-align: top;
-  border-radius: 100%;
-}
-
-.task-list-item-user-avatar {
-  width: 16px;
+  border-radius: 5px;
 }
 
 .task-list-item-repository-owner-avatar {
-  width: 30px;
+  width: 25px;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.task-list-item-user-avatar {
+  width: 20px;
+  position: absolute;
+  right: 0;
+  top: 17px;
 }

--- a/src/components/TaskListItem/TaskListItem.less
+++ b/src/components/TaskListItem/TaskListItem.less
@@ -1,6 +1,11 @@
 .task-list-item {
   font-size: 16px;
 
+  .octicon-link-external {
+    margin-top: 2px;
+    display: block;
+  }
+
   .checkbox.main-label {
     color: #333;
   }

--- a/src/components/TaskListItem/TaskListItem.less
+++ b/src/components/TaskListItem/TaskListItem.less
@@ -71,9 +71,11 @@ input.task-list-item-checkbox[type="checkbox"] {
 }
 
 .task-list-item-repository {
+  font-weight: 500;
 }
 
 .task-list-item-user {
+  font-weight: 500;
 }
 
 .task-list-item-repository-owner-column {

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -33,10 +33,10 @@ function getTask(data) {
     repository,
     repositoryOwner,
     repositoryOwnerUrl: `https://github.com/${repositoryOwner}`,
-    repositoryOwnerAvatar: `https://github.com/${repositoryOwner}.png?size=30`,
+    repositoryOwnerAvatar: `https://github.com/${repositoryOwner}.png?size=25`,
     user: data.user.login,
     userUrl: data.user.html_url,
-    userAvatar: `https://github.com/${data.user.login}.png?size=16`,
+    userAvatar: `https://github.com/${data.user.login}.png?size=20`,
     userType: data.user.type,
   }
 }


### PR DESCRIPTION
- Show the repo owner and task user avatars together in the same column.
- Vertically center the task date and the external link icons.
- Display the task creator and repo names in bold.

![screen shot 2016-10-15 at 2 06 38 pm](https://cloud.githubusercontent.com/assets/82317/19412685/acc58250-92e0-11e6-8ebe-96238b23771f.png)

/cc @probablycorey @summasmiff 
