### PR TITLE
Use keytar for GitHub access token storage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,4 @@ install:
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - npm install
   - ./node_modules/.bin/electron-rebuild
-  - eval $(gnome-keyring-daemon)
   - export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+sudo: false
 notifications:
   email: false
 language: node_js
 node_js:
 - "6"
+before_script:
+  - npm prune
 script:
   - "NODE_ENV=test npm run-script unit-tests"
   - "npm run-script style"
@@ -12,6 +15,7 @@ cache:
   - "$HOME/.npm"
   - "$HOME/.electron"
   - "/Library/Caches/Homebrew"
+  - node_modules
 env:
   - CC=clang CXX=clang++ npm_config_clang=1
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,14 @@ cache:
   - "$HOME/.npm"
   - "$HOME/.electron"
   - "/Library/Caches/Homebrew"
+env:
+  - CC=clang CXX=clang++ npm_config_clang=1
 addons:
   apt:
     packages:
       - xvfb
+      - gnome-keyring
+      - libgnome-keyring-dev
 before_install:
   - "npm config set spin false"
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,6 @@ install:
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - npm install
   - ./node_modules/.bin/electron-rebuild
+  - sudo service dbus start
+  - eval $(gnome-keyring-daemon)
+  - export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ install:
   - export DISPLAY=':99.0'
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - npm install
+  - ./node_modules/.bin/electron-rebuild

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
   apt:
     packages:
       - xvfb
-      - gnome-keyring
       - libgnome-keyring-dev
 before_install:
   - "npm config set spin false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,5 @@ install:
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   - npm install
   - ./node_modules/.bin/electron-rebuild
-  - sudo service dbus start
   - eval $(gnome-keyring-daemon)
   - export GNOME_KEYRING_CONTROL GNOME_KEYRING_PID GPG_AGENT_INFO SSH_AUTH_SOCK

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ of interest to you.
 
 You must provide a GitHub personal access token once you start the app the first
 time. [Create a token](https://github.com/settings/tokens/new) with the `repo`
-scope.
+scope. When running the app, your token will be stored in Keychain in macOS,
+Gnome Keyring in Linux, and Credential Vault in Windows.
 
 ## How to Develop
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,18 @@ scope.
 
 ## How to Develop
 
-This was developed with npm version 3.10.3 and node version 6.3.1
+This was developed with npm version 3.10.3 and node version 6.3.1.
 
 ### First-time Setup
+
+In Linux, you may need to run
+
+```bash
+sudo apt-get install libgnome-keyring-dev
+```
+
+first because this app uses gnome-keyring. Afterward, including for macOS and
+Windows:
 
 ```bash
 # Clone this repository

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Run the app with:
 npm start
 ```
 
+### Troubleshooting
+
+> When I run `npm start`, I get "Error: Module version mismatch. Expected 49, got 48" in the JavaScript console.
+
+Exit the app and try running:
+
+```bash
+./node_modules/.bin/electron-rebuild
+```
+
+Then run `npm start` again and see if the app loads.
+
 ## How to Run Tests
 
 How you set the `NODE_ENV` environment variable to run `npm test` may be different depending on your operating system and shell.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "xvfb-maybe": "^0.1.3"
   },
   "scripts": {
-    "postinstall": "./node_modules/.bin/electron-rebuild && node postinstall.js",
+    "postinstall": "node postinstall.js",
     "start": "electron src/main.js",
     "style": "eslint -c .eslintrc *.js scripts/* src/*.js src/**/*.jsx test/**/*.js",
     "unit-tests": "xvfb-maybe electron-mocha --renderer --recursive --compilers js:babel-register test",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "electron-mocha": "^2.3.1",
     "electron-prebuilt-compile": "^1.2.5",
+    "electron-rebuild": "^1.2.1",
     "eslint": "^3.0.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.11.0",
@@ -31,7 +32,7 @@
     "xvfb-maybe": "^0.1.3"
   },
   "scripts": {
-    "postinstall": "node postinstall.js",
+    "postinstall": "./node_modules/.bin/electron-rebuild && node postinstall.js",
     "start": "electron src/main.js",
     "style": "eslint -c .eslintrc *.js scripts/* src/*.js src/**/*.jsx test/**/*.js",
     "unit-tests": "xvfb-maybe electron-mocha --renderer --recursive --compilers js:babel-register test",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "electron-config": "^0.2.1",
     "isomorphic-fetch": "^2.2.1",
+    "keytar": "^3.0.2",
     "react": "^15.2.1",
     "react-autosuggest": "^6.0.4",
     "react-dom": "^15.2.1",

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -111,7 +111,6 @@ class Auth extends React.Component {
   }
 
   render() {
-    const authFile = GitHubAuth.path()
     return (
       <div>
         <nav id="auth-top-navigation" className="secondary-nav nav">
@@ -165,11 +164,6 @@ class Auth extends React.Component {
                 <span className="fa octicon octicon-key"></span>
               </p>
             </div>
-            <p className="help">
-              Your token
-              {this.props.isAuthenticated ? ' is stored ' : ' will be stored '}
-              in: <code>{authFile}</code>
-            </p>
             <p className="control">
               <button
                 type="submit"

--- a/src/components/Auth/Auth.jsx
+++ b/src/components/Auth/Auth.jsx
@@ -154,7 +154,7 @@ class Auth extends React.Component {
               </div>
               <p className="control is-fullwidth has-icon">
                 <input
-                  type="text"
+                  type="password"
                   name="token"
                   className={this.inputClass()}
                   value={this.state.token}

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -88,6 +88,7 @@ class GitHub extends Fetcher {
     if (!this.token) {
       this.token = GitHubAuth.getToken()
     }
+    console.log('token', this.token)
     return {
       Accept: 'application/vnd.github.v3+json',
       Authorization: `token ${this.token}`,

--- a/src/models/GitHub.js
+++ b/src/models/GitHub.js
@@ -88,7 +88,6 @@ class GitHub extends Fetcher {
     if (!this.token) {
       this.token = GitHubAuth.getToken()
     }
-    console.log('token', this.token)
     return {
       Accept: 'application/vnd.github.v3+json',
       Authorization: `token ${this.token}`,

--- a/src/models/GitHubAuth.js
+++ b/src/models/GitHubAuth.js
@@ -3,7 +3,7 @@
 import keytar from 'keytar'
 
 const SERVICE = 'gh-notifications-snoozer'
-const ACCOUNT = 'github'
+const ACCOUNT = process.env.NODE_ENV === 'test' ? 'github-test' : 'github'
 
 class GitHubAuth {
   static isAuthenticated() {

--- a/src/models/GitHubAuth.js
+++ b/src/models/GitHubAuth.js
@@ -11,6 +11,7 @@ class GitHubAuth {
   }
 
   static setToken(token) {
+    console.log('setToken', token)
     if (this.isAuthenticated()) {
       this.deleteToken()
     }
@@ -22,6 +23,7 @@ class GitHubAuth {
   }
 
   static getToken() {
+    console.log('getToken', keytar.getPassword(SERVICE, ACCOUNT))
     return keytar.getPassword(SERVICE, ACCOUNT)
   }
 }

--- a/src/models/GitHubAuth.js
+++ b/src/models/GitHubAuth.js
@@ -1,30 +1,28 @@
 'use strict'
 
-const ElectronConfig = require('electron-config')
-const configName = process.env.NODE_ENV === 'test' ? 'config-test' : 'config'
-const storage = new ElectronConfig({ name: configName })
+import keytar from 'keytar'
 
-const KEY = 'token'
+const SERVICE = 'gh-notifications-snoozer'
+const ACCOUNT = 'github'
 
 class GitHubAuth {
   static isAuthenticated() {
-    return storage.has(KEY)
+    return this.getToken() !== null
   }
 
   static setToken(token) {
-    storage.set(KEY, token)
+    if (this.isAuthenticated()) {
+      this.deleteToken()
+    }
+    keytar.addPassword(SERVICE, ACCOUNT, token)
   }
 
   static deleteToken() {
-    storage.delete(KEY)
+    keytar.deletePassword(SERVICE, ACCOUNT)
   }
 
   static getToken() {
-    return storage.get(KEY)
-  }
-
-  static path() {
-    return storage.path
+    return keytar.getPassword(SERVICE, ACCOUNT)
   }
 }
 

--- a/test/components/AppTest.js
+++ b/test/components/AppTest.js
@@ -95,7 +95,6 @@ describe('App', () => {
 
       setTimeout(() => {
         const fetchedCalls = fetchMock.calls().matched
-        console.log('fetchedCalls', fetchedCalls)
         assert(fetchedCalls[0][0].match(/\/user/),
                'Fetch call should be to the user API')
         assert(fetchedCalls[1][0].match(/\/search\/issues/),

--- a/test/components/AppTest.js
+++ b/test/components/AppTest.js
@@ -47,6 +47,8 @@ describe('App', () => {
     })
 
     it('does not make request without a token', () => {
+      GitHubAuth.deleteToken()
+
       renderPage(store)
 
       const fetchedCalls = fetchMock.calls().matched

--- a/test/components/AppTest.js
+++ b/test/components/AppTest.js
@@ -95,6 +95,7 @@ describe('App', () => {
 
       setTimeout(() => {
         const fetchedCalls = fetchMock.calls().matched
+        console.log('fetchedCalls', fetchedCalls)
         assert(fetchedCalls[0][0].match(/\/user/),
                'Fetch call should be to the user API')
         assert(fetchedCalls[1][0].match(/\/search\/issues/),


### PR DESCRIPTION
Fixes #52 by storing the GitHub access token in secure storage based on the operating system, instead of in a plain JSON file.

/cc @summasmiff @probablycorey 
