### PR TITLE
Show a message when there are no tasks to display

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -49,6 +49,7 @@ class App extends React.Component {
       this.setState({ loadingTasks: false })
     }).catch(err => {
       console.error('failed to get tasks from GitHub', err)
+      this.setState({ loadingTasks: false })
     })
   }
 
@@ -159,6 +160,7 @@ class App extends React.Component {
       this.onNotificationsFetched(notifications, query)
     }).catch(err => {
       console.error('failed to get notifications from GitHub', err)
+      this.setState({ loadingTasks: false })
     })
   }
 

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -25,6 +25,7 @@ class App extends React.Component {
       view,
       filters: Filters.findAll(),
       filter: LastFilter.retrieve(),
+      loadingTasks: true,
     }
   }
 
@@ -45,6 +46,7 @@ class App extends React.Component {
     const github = new GitHub()
     github.getTasks(query).then(tasks => {
       this.props.dispatch({ type: 'TASKS_UPDATE', tasks, notifications })
+      this.setState({ loadingTasks: false })
     }).catch(err => {
       console.error('failed to get tasks from GitHub', err)
     })
@@ -100,6 +102,7 @@ class App extends React.Component {
           showAuth={() => this.showAuth()}
           showHidden={() => this.showHidden()}
           editFilter={editFilter}
+          loading={this.state.loadingTasks}
         />)
       case 'filters': return (
         <FilterList
@@ -190,7 +193,7 @@ class App extends React.Component {
     this.props.dispatch({ type: 'TASKS_EMPTY' })
     LastFilter.save(key)
     const filter = new Filter(key)
-    this.setState({ filter: key })
+    this.setState({ filter: key, loadingTasks: true })
     const query = filter.retrieve()
     this.loadTasks(query)
   }

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -210,13 +210,29 @@ class TaskList extends React.Component {
           </div>
         </nav>
         <div className="task-list-container">
-          <ol className="task-list">
-            {this.props.tasks.map((task, index) => {
-              const isFocused = index === this.state.selectedIndex
-              const key = `${task.storageKey}-${task.isSelected}-${isFocused}`
-              return <TaskListItem {...task} key={key} isFocused={isFocused} />
-            })}
-          </ol>
+          {this.props.tasks.length > 0 ? (
+            <ol className="task-list">
+              {this.props.tasks.map((task, index) => {
+                const isFocused = index === this.state.selectedIndex
+                const key = `${task.storageKey}-${task.isSelected}-${isFocused}`
+                return (
+                  <TaskListItem
+                    {...task}
+                    key={key}
+                    isFocused={isFocused}
+                  />
+                )
+              })}
+            </ol>
+          ) : (
+            <p>
+              {this.props.loading ? (
+                <span>Loading...</span>
+              ) : (
+                <span>You&rsquo;ve reached the end!</span>
+              )}
+            </p>
+          )}
         </div>
       </div>
     )
@@ -233,6 +249,7 @@ TaskList.propTypes = {
   showAuth: React.PropTypes.func.isRequired,
   showHidden: React.PropTypes.func.isRequired,
   editFilter: React.PropTypes.func.isRequired,
+  loading: React.PropTypes.bool.isRequired,
 }
 
 const stickyNavd = hookUpStickyNav(TaskList, '.task-list-navigation')

--- a/src/models/AppMenu.js
+++ b/src/models/AppMenu.js
@@ -12,6 +12,7 @@ class AppMenu extends EventEmitter {
     super()
     this.options = options
     this.template = []
+    this.altOrOption = process.platform === 'darwin' ? 'Option' : 'Alt'
     const self = this
     this.aboutOption = {
       label: `About ${app.getName()}`,
@@ -97,7 +98,7 @@ class AppMenu extends EventEmitter {
       submenu: [
         {
           label: 'Developer Tools',
-          accelerator: 'CmdOrCtrl+Shift+I',
+          accelerator: `CmdOrCtrl+${this.altOrOption}+I`,
           click(item, win) {
             if (win) {
               win.webContents.toggleDevTools()


### PR DESCRIPTION
When tasks are still loading, show a 'Loading...' message. When tasks have finished loading but there are none to display, show another message. Fixes #66.

Also changes the shortcut to toggle the developer tools to be Cmd-Option-I in macOS and Ctrl-Alt-I in Windows and Linux. This matches the shortcut in Chrome.

/cc @probablycorey @summasmiff 
