### PR TITLE
Add keyboard shortcuts for archive, snooze, ignore

### DIFF
--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -87,6 +87,15 @@ class App extends React.Component {
         this.manageFilters()
       }
     })
+    this.appMenu.on('archive', () => {
+      this.props.dispatch({ type: 'TASKS_ARCHIVE' })
+    })
+    this.appMenu.on('ignore', () => {
+      this.props.dispatch({ type: 'TASKS_IGNORE' })
+    })
+    this.appMenu.on('snooze', () => {
+      this.props.dispatch({ type: 'TASKS_SNOOZE' })
+    })
   }
 
   getViewContents() {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -135,7 +135,7 @@ class App extends React.Component {
           loadPrevPage={loadPrevPage}
           currentPage={currentPage}
           loading={this.state.loadingTasks}
-          toggleTaskOptions={enabled => this.toggleTaskOptions(enabled)}
+          appMenu={this.appMenu}
         />)
       case 'filters': return (
         <FilterList
@@ -174,10 +174,6 @@ class App extends React.Component {
         />
       )
     }
-  }
-
-  toggleTaskOptions(enabled) {
-    this.appMenu.toggleTaskOptions(enabled)
   }
 
   loadNextPage() {

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -96,6 +96,9 @@ class App extends React.Component {
     this.appMenu.on('snooze', () => {
       this.props.dispatch({ type: 'TASKS_SNOOZE' })
     })
+    this.appMenu.on('restore', () => {
+      this.props.dispatch({ type: 'TASKS_RESTORE' })
+    })
   }
 
   getViewContents() {
@@ -165,6 +168,7 @@ class App extends React.Component {
         <HiddenTaskList
           cancel={cancel}
           activeFilter={this.state.filter}
+          appMenu={this.appMenu}
         />)
       default: return (
         <Auth

--- a/src/components/App/App.jsx
+++ b/src/components/App/App.jsx
@@ -126,6 +126,7 @@ class App extends React.Component {
           loadPrevPage={loadPrevPage}
           currentPage={currentPage}
           loading={this.state.loadingTasks}
+          toggleTaskOptions={enabled => this.toggleTaskOptions(enabled)}
         />)
       case 'filters': return (
         <FilterList
@@ -164,6 +165,10 @@ class App extends React.Component {
         />
       )
     }
+  }
+
+  toggleTaskOptions(enabled) {
+    this.appMenu.toggleTaskOptions(enabled)
   }
 
   loadNextPage() {

--- a/src/components/HiddenTaskList/HiddenTaskList.jsx
+++ b/src/components/HiddenTaskList/HiddenTaskList.jsx
@@ -30,8 +30,12 @@ class HiddenTaskList extends React.Component {
 
   render() {
     const { activeFilter } = this.props
-    const isRestoreDisabled = this.props.tasks.
-        filter(task => task.isSelected).length < 1
+    const anyTaskSelected = this.props.tasks.
+        filter(task => task.isSelected).length > 0
+    const isRestoreDisabled = !anyTaskSelected
+    if (this.props.appMenu) {
+      this.props.appMenu.toggleTaskOptions(anyTaskSelected, 'restore')
+    }
     return (
       <div>
         <nav id="hidden-task-list-navigation" className="secondary-nav nav">
@@ -73,6 +77,7 @@ HiddenTaskList.propTypes = {
   dispatch: React.PropTypes.func.isRequired,
   cancel: React.PropTypes.func.isRequired,
   activeFilter: React.PropTypes.string.isRequired,
+  appMenu: React.PropTypes.object,
 }
 
 const stickyNavd = hookUpStickyNav(HiddenTaskList,

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -197,6 +197,9 @@ class TaskList extends React.Component {
         filter(task => task.isSelected).length < 1
     const isArchiveDisabled = isSnoozeDisabled
     const isIgnoreDisabled = isSnoozeDisabled
+    if (this.props.tasks.filter(task => task.isSelected).length > 0) {
+      this.props.toggleTaskOptions(true)
+    }
     return (
       <div>
         <nav className="task-list-navigation secondary-nav nav has-tertiary-nav">

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -223,22 +223,22 @@ class TaskList extends React.Component {
             <span className="nav-item compact-vertically">
               <button
                 type="button"
-                onClick={e => this.onSnoozeClick(e)}
-                className="control button is-link"
-                id="snooze-button"
-                title="Snooze selected"
-                disabled={isSnoozeDisabled}
-              >😴 Snooze</button>
-            </span>
-            <span className="nav-item compact-vertically">
-              <button
-                type="button"
                 id="archive-button"
                 className="control button is-link"
                 onClick={e => this.onArchiveClick(e)}
                 title="Archive selected"
                 disabled={isArchiveDisabled}
               >📥 Archive</button>
+            </span>
+            <span className="nav-item compact-vertically">
+              <button
+                type="button"
+                onClick={e => this.onSnoozeClick(e)}
+                className="control button is-link"
+                id="snooze-button"
+                title="Snooze selected"
+                disabled={isSnoozeDisabled}
+              >😴 Snooze</button>
             </span>
             <span className="nav-item compact-vertically">
               <button

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -51,6 +51,7 @@ class TaskList extends React.Component {
       this.focusNextTask()
     } else if (event.key === 'Escape') {
       this.setState({ selectedIndex: null })
+      this.props.toggleTaskOptions(false)
     } else if (event.key === 'Enter') {
       if (typeof this.state.selectedIndex === 'number') {
         this.openLinkToFocusedTask()
@@ -136,6 +137,7 @@ class TaskList extends React.Component {
   focusTaskAtIndex(index) {
     console.info('focus task', this.props.tasks[index].storageKey)
     this.setState({ selectedIndex: index })
+    this.props.toggleTaskOptions(true)
   }
 
   taskListOrMessage() {
@@ -301,6 +303,7 @@ TaskList.propTypes = {
   loadNextPage: React.PropTypes.func,
   currentPage: React.PropTypes.number,
   loading: React.PropTypes.bool.isRequired,
+  toggleTaskOptions: React.PropTypes.func.isRequired,
 }
 
 const stickyNavd = hookUpStickyNav(TaskList, '.task-list-navigation')

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -69,6 +69,15 @@ class TaskList extends React.Component {
     }
   }
 
+  getFocusIndex() {
+    if (typeof this.props.focusedTask !== 'object') {
+      return null
+    }
+    const needle = this.props.focusedTask.storageKey
+    const haystack = this.props.tasks.map(task => task.storageKey)
+    return haystack.indexOf(needle)
+  }
+
   loadNextPage(event) {
     event.currentTarget.blur() // defocus button
     this.props.loadNextPage()
@@ -110,15 +119,6 @@ class TaskList extends React.Component {
 
   openLinkToFocusedTask() {
     shell.openExternal(this.props.focusedTask.url)
-  }
-
-  getFocusIndex() {
-    if (typeof this.props.focusedTask !== 'object') {
-      return null
-    }
-    const needle = this.props.focusedTask.storageKey
-    const haystack = this.props.tasks.map(task => task.storageKey)
-    return haystack.indexOf(needle)
   }
 
   focusNextTask() {

--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -49,7 +49,6 @@ class TaskList extends React.Component {
     } else if (event.key === 'ArrowDown') {
       this.focusNextTask()
     } else if (event.key === 'Escape') {
-      this.props.toggleTaskOptions(false)
       this.props.dispatch({ type: 'TASKS_DEFOCUS' })
     } else if (event.key === 'Enter') {
       if (typeof this.props.focusedTask === 'object') {
@@ -144,7 +143,6 @@ class TaskList extends React.Component {
   focusTaskAtIndex(index) {
     const storageKey = this.props.tasks[index].storageKey
     this.props.dispatch({ type: 'TASKS_FOCUS', task: { storageKey } })
-    this.props.toggleTaskOptions(true)
   }
 
   taskListOrMessage() {
@@ -193,12 +191,13 @@ class TaskList extends React.Component {
   render() {
     const filters = Filters.findAll()
     const lastFilterKey = LastFilter.retrieve()
-    const isSnoozeDisabled = this.props.tasks.
-        filter(task => task.isSelected).length < 1
+    const anyTaskSelected = this.props.tasks.
+        filter(task => task.isSelected).length > 0
+    const isSnoozeDisabled = !anyTaskSelected
     const isArchiveDisabled = isSnoozeDisabled
     const isIgnoreDisabled = isSnoozeDisabled
-    if (this.props.tasks.filter(task => task.isSelected).length > 0) {
-      this.props.toggleTaskOptions(true)
+    if (this.props.appMenu) {
+      this.props.appMenu.toggleTaskOptions(anyTaskSelected)
     }
     return (
       <div>
@@ -306,8 +305,8 @@ TaskList.propTypes = {
   loadNextPage: React.PropTypes.func,
   currentPage: React.PropTypes.number,
   loading: React.PropTypes.bool.isRequired,
-  toggleTaskOptions: React.PropTypes.func.isRequired,
   focusedTask: React.PropTypes.object,
+  appMenu: React.PropTypes.object,
 }
 
 const stickyNavd = hookUpStickyNav(TaskList, '.task-list-navigation')

--- a/src/components/TaskListItem/TaskListItem.jsx
+++ b/src/components/TaskListItem/TaskListItem.jsx
@@ -157,7 +157,7 @@ TaskListItem.propTypes = {
   repository: React.PropTypes.string.isRequired,
   isPullRequest: React.PropTypes.bool.isRequired,
   isSelected: React.PropTypes.bool,
-  isFocused: React.PropTypes.bool.isRequired,
+  isFocused: React.PropTypes.bool,
 }
 
 module.exports = connect()(TaskListItem)

--- a/src/models/AppMenu.js
+++ b/src/models/AppMenu.js
@@ -125,6 +125,7 @@ class AppMenu extends EventEmitter {
     this.template.push(this.getAppMenu())
     this.template.push(this.getEditMenu())
     this.template.push(this.getViewMenu())
+    this.template.push(this.getTaskMenu())
     this.template.push(this.getToolsMenu())
     this.template.push({
       label: 'Help',
@@ -148,10 +149,38 @@ class AppMenu extends EventEmitter {
     }
   }
 
+  getTaskMenu() {
+    const self = this
+    return {
+      label: 'Task',
+      submenu: [
+        {
+          label: 'Archive',
+          accelerator: `Ctrl+${this.altOrOption}+A`,
+          click() { self.emit('archive') },
+          enabled: false,
+        },
+        {
+          label: 'Snooze',
+          accelerator: `Ctrl+${this.altOrOption}+S`,
+          click() { self.emit('snooze') },
+          enabled: false,
+        },
+        {
+          label: 'Ignore',
+          accelerator: `Ctrl+${this.altOrOption}+I`,
+          click() { self.emit('ignore') },
+          enabled: false,
+        },
+      ],
+    }
+  }
+
   buildNonOSXMenu() {
     this.template.push(this.getFileMenu())
     this.template.push(this.getEditMenu())
     this.template.push(this.getViewMenu())
+    this.template.push(this.getTaskMenu())
     this.template.push(this.getToolsMenu())
     this.template.push({
       label: 'Help',

--- a/src/models/AppMenu.js
+++ b/src/models/AppMenu.js
@@ -62,6 +62,13 @@ class AppMenu extends EventEmitter {
     viewMenu.items[1].enabled = isAuthenticated // Filters
   }
 
+  toggleTaskOptions(enabled) {
+    const taskMenu = this.menu.items[3].submenu
+    taskMenu.items[0].enabled = enabled // Archive
+    taskMenu.items[1].enabled = enabled // Snooze
+    taskMenu.items[2].enabled = enabled // Ignore
+  }
+
   getViewMenu() {
     const self = this
     return {

--- a/src/models/AppMenu.js
+++ b/src/models/AppMenu.js
@@ -62,11 +62,19 @@ class AppMenu extends EventEmitter {
     viewMenu.items[1].enabled = isAuthenticated // Filters
   }
 
-  toggleTaskOptions(enabled) {
+  toggleTaskOptions(enabled, type) {
     const taskMenu = this.menu.items[3].submenu
-    taskMenu.items[0].enabled = enabled // Archive
-    taskMenu.items[1].enabled = enabled // Snooze
-    taskMenu.items[2].enabled = enabled // Ignore
+    if (type === 'restore') {
+      taskMenu.items[0].enabled = false // Archive
+      taskMenu.items[1].enabled = false // Snooze
+      taskMenu.items[2].enabled = false // Ignore
+      taskMenu.items[3].enabled = enabled // Restore
+    } else {
+      taskMenu.items[0].enabled = enabled // Archive
+      taskMenu.items[1].enabled = enabled // Snooze
+      taskMenu.items[2].enabled = enabled // Ignore
+      taskMenu.items[3].enabled = false // Restore
+    }
   }
 
   getViewMenu() {
@@ -177,6 +185,12 @@ class AppMenu extends EventEmitter {
           label: 'Ignore',
           accelerator: `Ctrl+${this.altOrOption}+I`,
           click() { self.emit('ignore') },
+          enabled: false,
+        },
+        {
+          label: 'Restore',
+          accelerator: `Ctrl+${this.altOrOption}+R`,
+          click() { self.emit('restore') },
           enabled: false,
         },
       ],

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -93,10 +93,10 @@ function focusTasks(tasks, action) {
   const updatedTasks = tasks.map(task => {
     if (task.storageKey === action.task.storageKey) {
       focusedTasks.push(task)
-      return Object.assign({}, task, { isFocused: true })
+      return Object.assign({}, task, { isFocused: true, isSelected: true })
     }
     if (task.isFocused) {
-      return Object.assign({}, task, { isFocused: null })
+      return Object.assign({}, task, { isFocused: null, isSelected: null })
     }
     return task
   })
@@ -122,7 +122,7 @@ function defocusTasks(tasks) {
   const updatedTasks = tasks.map(task => {
     if (task.isFocused) {
       defocusedTasks.push(task)
-      return Object.assign({}, task, { isFocused: null })
+      return Object.assign({}, task, { isFocused: null, isSelected: null })
     }
     return task
   })

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -88,6 +88,22 @@ function updateTasks(tasks, action) {
   return updatedTasks
 }
 
+function focusTasks(tasks, action) {
+  const focusedTasks = []
+  const updatedTasks = tasks.map(task => {
+    if (task.storageKey === action.task.storageKey) {
+      focusedTasks.push(task)
+      return Object.assign({}, task, { isFocused: true })
+    }
+    if (task.isFocused) {
+      return Object.assign({}, task, { isFocused: null })
+    }
+    return task
+  })
+  console.info('focus', focusedTasks.map(task => task.storageKey))
+  return updatedTasks
+}
+
 function selectTasks(tasks, action) {
   const selectedTasks = []
   const updatedTasks = tasks.map(task => {
@@ -98,6 +114,19 @@ function selectTasks(tasks, action) {
     return task
   })
   console.info('select', selectedTasks.map(task => task.storageKey))
+  return updatedTasks
+}
+
+function defocusTasks(tasks) {
+  const defocusedTasks = []
+  const updatedTasks = tasks.map(task => {
+    if (task.isFocused) {
+      defocusedTasks.push(task)
+      return Object.assign({}, task, { isFocused: null })
+    }
+    return task
+  })
+  console.info('defocus', defocusedTasks.map(task => task.storageKey))
   return updatedTasks
 }
 
@@ -235,6 +264,10 @@ function tasksReducer(tasks = [], action) {
       return ignoreTasks(tasks)
     case 'TASKS_RESTORE':
       return restoreTasks(tasks)
+    case 'TASKS_FOCUS':
+      return focusTasks(tasks, action)
+    case 'TASKS_DEFOCUS':
+      return defocusTasks(tasks)
     default:
       return tasks
   }


### PR DESCRIPTION
Fixes #50 and fixes #101.

This adds a Task menu with options Archive, Snooze, Ignore, and Restore. Those options become enabled as necessary based on whether hidden or visible tasks are being viewed and whether or not there are any tasks selected.

To do this, the concept of 'focusing' a task to highlight which one you're looking at is now part of Redux storage instead of regular React per-component state. Also when you use the arrow keys to focus a task, it also changes task selection.

Having task focus as part of persistent Redux state may help users to keep track of where they left off.

I'm open to feedback as to the shortcuts being used. It's Ctrl+Option+letter right now for archive/snooze/ignore/restore. Maybe it should just be the letter only, e.g., A for archive.

/cc @summasmiff @probablycorey 
