### PR TITLE
add electron-devtools-installer dev dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "concurrently": "^3.1.0",
+    "electron-devtools-installer": "^2.0.1",
     "eslint": "^3.0.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.11.0",


### PR DESCRIPTION
👋 

I was getting an error until I installed it.

```
> concurrently "npm run watch-css" "electron ."

[0] 
[0] > GHSnooze@0.0.1 watch-css /Users/zeke/forks/gh-notifications-snoozer
[0] > less-watch-compiler src src components/App/App.less
[0] 
[0] Watching directory for file changes.
[0] 
[1] App threw an error during load
[1] Error: Cannot find module 'electron-devtools-installer'
[1]     at Module._resolveFilename (module.js:455:15)
[1]     at Function.Module._resolveFilename (/Users/zeke/forks/gh-notifications-snoozer/node_modules/electron/dist/Electron.app/Contents/Resources/electron.asar/common/reset-search-paths.js:35:12)
[1]     at Function.Module._load (module.js:403:25)
[1]     at Module.require (module.js:483:17)
[1]     at require (internal/module.js:20:19)
[1]     at Object.<anonymous> (/Users/zeke/forks/gh-notifications-snoozer/src/main.js:8:24)
[1]     at Module._compile (module.js:556:32)
[1]     at Object.require.extensions.(anonymous function) [as .js] (/Users/zeke/forks/gh-notifications-snoozer/node_modules/electron-compile/lib/require-hook.js:36:14)
[1]     at Module.load (module.js:473:32)
[1]     at tryModuleLoad (module.js:432:12)
```