### PR TITLE
Don't always require electron-devtools-installer

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
     "no-console": 0,
     "react/prefer-stateless-function": 0,
     "import/no-unresolved": 0,
-    "arrow-parens": ["error", "as-needed"]
+    "arrow-parens": ["error", "as-needed"],
+    "global-require": 0
   },
   "ecmaFeatures": {
     "jsx": true

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,8 @@
 const { app, BrowserWindow, ipcMain } = require('electron')
-const installExtension = require('electron-devtools-installer')
+let installExtension = null
+if (process.env.NODE_ENV === 'development') {
+  installExtension = require('electron-devtools-installer')
+}
 
 let mainWindow
 
@@ -19,11 +22,13 @@ function createWindow() {
 }
 
 app.on('ready', () => {
-  installExtension.default(installExtension.REACT_DEVELOPER_TOOLS)
-    .then(name => console.log(`Added Extension:  ${name}`))
-    .then(() => installExtension.default(installExtension.REDUX_DEVTOOLS)
-    .then(name => console.log(`Added Extension:  ${name}`)))
-    .catch(err => console.log('An error occurred: ', err))
+  if (installExtension) {
+    installExtension.default(installExtension.REACT_DEVELOPER_TOOLS)
+      .then(name => console.log(`Added Extension:  ${name}`))
+      .then(() => installExtension.default(installExtension.REDUX_DEVTOOLS)
+      .then(name => console.log(`Added Extension:  ${name}`)))
+      .catch(err => console.log('An error occurred: ', err))
+  }
 
   app.setAppUserModelId('com.gh-notifications-snoozer.app')
 


### PR DESCRIPTION
The electron-devtools-installer package can be useful when developing, but when you just want to run the app, you shouldn't need it installed. Fixes #117.

/cc @probablycorey @shayfrendt