### PR TITLE
Fixes problem with archivedAt

### DIFF
--- a/src/components/TaskList/TaskList.jsx
+++ b/src/components/TaskList/TaskList.jsx
@@ -105,7 +105,11 @@ class TaskList extends React.Component {
   }
 
   archive() {
-    this.props.dispatch({ type: 'TASKS_ARCHIVE', task: this.focusedTask() })
+    this.props.dispatch({
+      type: 'TASKS_ARCHIVE',
+      task: this.focusedTask(),
+      filter: this.props.activeFilter,
+    })
   }
 
   ignore() {

--- a/src/models/TaskVisibility.js
+++ b/src/models/TaskVisibility.js
@@ -27,7 +27,7 @@ class TaskVisibility {
     if (typeof archivedAt === 'string') {
       const updateDate = new Date(updatedAt)
       const archiveDate = new Date(archivedAt)
-      if (archiveDate > updateDate) {
+      if (archiveDate >= updateDate) {
         // Has not been updated since it was archived, hide it
         return true
       }

--- a/src/reducers/TasksReducer.js
+++ b/src/reducers/TasksReducer.js
@@ -75,7 +75,7 @@ function ignoreTask(existingTasks, { task: taskToUpdate }) {
 function archiveTask(existingTasks, { task: taskToUpdate }) {
   const newValues = {
     snoozedAt: null,
-    archivedAt: new Date().toISOString(),
+    archivedAt: taskToUpdate.updatedAt,
     ignore: false,
     changelog: {},
   }

--- a/src/reducers/TasksReducer.js
+++ b/src/reducers/TasksReducer.js
@@ -72,10 +72,10 @@ function ignoreTask(existingTasks, { task: taskToUpdate }) {
   return updateTask(existingTasks, taskToUpdate, newValues)
 }
 
-function archiveTask(existingTasks, { task: taskToUpdate }) {
+function archiveTask(existingTasks, { task: taskToUpdate, filter }) {
   const newValues = {
     snoozedAt: null,
-    archivedAt: taskToUpdate.updatedAt,
+    archivedAt: filter.updatedAt,
     ignore: false,
     changelog: {},
   }

--- a/test/components/TaskListTest.js
+++ b/test/components/TaskListTest.js
@@ -49,8 +49,10 @@ describe('TaskList', () => {
   })
 
   it('does not show task that is archived', () => {
+    const filter = { updatedAt: '2015-01-01T01:01:01.000Z' }
+
     assert.equal(1, renderedDOM().querySelectorAll('#pull-163031382').length)
-    store.dispatch({ type: 'TASKS_ARCHIVE', task: { storageKey: 'pull-163031382' } })
+    store.dispatch({ type: 'TASKS_ARCHIVE', task: { storageKey: 'pull-163031382' }, filter })
     assert.equal(0, renderedDOM().querySelectorAll('#pull-163031382').length)
     store.dispatch({ type: 'TASKS_RESTORE', task: { storageKey: 'pull-163031382' } })
   })

--- a/test/components/TaskListTest.js
+++ b/test/components/TaskListTest.js
@@ -19,7 +19,12 @@ describe('TaskList', () => {
     simple.mock(GitHubAuth, 'getToken').returnWith('test-whee')
 
     // Setup Redux store and render app
-    const filters = [{ name: 'Cool name', query: 'cats', selected: true }]
+    const filters = [{
+      name: 'Cool name',
+      query: 'cats',
+      selected: true,
+      updatedAt: '2017-01-01T01:01:01.000Z',
+    }]
     const tasks = [fixtures.task]
 
     store = Redux.createStore(reducer, { filters, tasks })
@@ -49,7 +54,7 @@ describe('TaskList', () => {
   })
 
   it('does not show task that is archived', () => {
-    const filter = { updatedAt: '2015-01-01T01:01:01.000Z' }
+    const filter = { updatedAt: '2017-01-01T01:01:01.000Z' }
 
     assert.equal(1, renderedDOM().querySelectorAll('#pull-163031382').length)
     store.dispatch({ type: 'TASKS_ARCHIVE', task: { storageKey: 'pull-163031382' }, filter })

--- a/test/reducers/TasksReducerTest.js
+++ b/test/reducers/TasksReducerTest.js
@@ -39,31 +39,34 @@ describe('Tasks reducer', () => {
     it('archives the selected task', () => {
       const initialTasks = [fixtures.task, fixtures.anotherTask]
 
+      const filter = { updatedAt: '2015-01-01T01:01:01.000Z' }
       const store = Redux.createStore(reducer, { tasks: initialTasks })
-      store.dispatch({ type: 'TASKS_ARCHIVE', task: fixtures.task })
+      store.dispatch({ type: 'TASKS_ARCHIVE', task: fixtures.task, filter })
 
       const archivedTask = store.getState().tasks.find(t => t.archivedAt)
       assert.isNotNaN(Date.parse(archivedTask.archivedAt), 'archivedAt should be a string date')
     })
 
-    it('uses the updatedAt date as the archivedAt date', () => {
+    it('uses the filter\'s updatedAt date as the archivedAt date', () => {
       // Since the issue could have been updated between the time it was updated
       // and when they press archive, it should only archive it at the last updated time
       const initialTasks = [fixtures.task, fixtures.anotherTask]
 
+      const filter = { updatedAt: '2015-01-01T01:01:01.000Z' }
       const store = Redux.createStore(reducer, { tasks: initialTasks })
-      store.dispatch({ type: 'TASKS_ARCHIVE', task: fixtures.task })
+      store.dispatch({ type: 'TASKS_ARCHIVE', task: fixtures.task, filter })
 
       const archivedTask = store.getState().tasks.find(t => t.archivedAt)
-      assert.equal(archivedTask.archivedAt, archivedTask.updatedAt)
+      assert.equal(archivedTask.archivedAt, filter.updatedAt)
     })
 
     it('clears changelog when the task is archived', () => {
       const task = Object.assign({}, fixtures.task, { changelog: { comments: 100 } })
       const initialTasks = [task]
 
+      const filter = { updatedAt: '2015-01-01T01:01:01.000Z' }
       const store = Redux.createStore(reducer, { tasks: initialTasks })
-      store.dispatch({ type: 'TASKS_ARCHIVE', task })
+      store.dispatch({ type: 'TASKS_ARCHIVE', task, filter })
 
       const archivedTask = store.getState().tasks[0]
 

--- a/test/reducers/TasksReducerTest.js
+++ b/test/reducers/TasksReducerTest.js
@@ -46,6 +46,18 @@ describe('Tasks reducer', () => {
       assert.isNotNaN(Date.parse(archivedTask.archivedAt), 'archivedAt should be a string date')
     })
 
+    it('uses the updatedAt date as the archivedAt date', () => {
+      // Since the issue could have been updated between the time it was updated
+      // and when they press archive, it should only archive it at the last updated time
+      const initialTasks = [fixtures.task, fixtures.anotherTask]
+
+      const store = Redux.createStore(reducer, { tasks: initialTasks })
+      store.dispatch({ type: 'TASKS_ARCHIVE', task: fixtures.task })
+
+      const archivedTask = store.getState().tasks.find(t => t.archivedAt)
+      assert.equal(archivedTask.archivedAt, archivedTask.updatedAt)
+    })
+
     it('clears changelog when the task is archived', () => {
       const task = Object.assign({}, fixtures.task, { changelog: { comments: 100 } })
       const initialTasks = [task]


### PR DESCRIPTION
Currently, when you archive a task it sets the task's archived at to the current time. But what happens in this scenario?

1. The filter is refreshed and issues are updated.
2. I open and look at an issue
3. On GitHub an issue gets another comment.
4. A few minutes later I archive the issue without seeing that new comment.
5. Next time the filter is refreshed, the issue will still be hidden

This is a problem. This PR fixes that by setting archivedAt to the filter's updatedAt value. So the situation will now look like this:

1. The filter is refreshed and issues are updated.
2. I open and look at an issue.
3. On GitHub an issue gets another comment.
4. A few minutes later I archive the issue without seeing that new comment.
5. Next time the filter is refreshed, the issue will be unarchived because its updatedAt value is set to the time in step 1.

cc @cheshire137 